### PR TITLE
Switch Death Check

### DIFF
--- a/template-parts/content-post_type_characters.php
+++ b/template-parts/content-post_type_characters.php
@@ -82,10 +82,10 @@ $gender_sexuality = lwtv_yikes_chardata( get_the_ID(), 'gender' ) . ' &bull; ' .
 			<?php if ( isset( $show_title ) && count( $show_title ) !== 0 ) echo $appears; ?>
 		</div>
 		<div class="card-meta-item">
-			<?php 
-				if ( isset( $dead_or_alive ) ) echo $dead_or_alive . '</br>';
-				if ( isset( $rip ) ) echo $rip;
-			?>
+			<?php if ( isset( $dead_or_alive ) ) echo $dead_or_alive . '</br>'; ?>
+		</div>
+		<div class="card-meta-item">
+			<?php if ( isset( $rip ) ) echo $rip; ?>
 		</div>
 	</div>
 	<div class="characters-description">

--- a/template-parts/content-post_type_characters.php
+++ b/template-parts/content-post_type_characters.php
@@ -33,6 +33,11 @@ $all_actors  = lwtv_yikes_chardata( get_the_ID(), 'actors' );
 $actor_title = _n( 'Actor', 'Actors', count( $all_actors ) );
 $actors      = '<strong>' . $actor_title . ':</strong> ' . implode( ", ", $all_actors );
 
+// Generate Status
+// Usage: $dead_or_alive
+$doa_status    = ( has_term( 'dead', 'lez_cliches' , get_the_ID() ) )? 'Dead' : 'Alive';
+$dead_or_alive = '<strong>Status:</strong> ' . $doa_status;
+
 // Generate RIP
 // Usage: $rip
 if ( get_post_meta( get_the_ID(), 'lezchars_death_year', true ) ) {
@@ -77,7 +82,10 @@ $gender_sexuality = lwtv_yikes_chardata( get_the_ID(), 'gender' ) . ' &bull; ' .
 			<?php if ( isset( $show_title ) && count( $show_title ) !== 0 ) echo $appears; ?>
 		</div>
 		<div class="card-meta-item">
-			<?php if ( isset( $rip ) ) echo $rip ; ?>
+			<?php 
+				if ( isset( $dead_or_alive ) ) echo $dead_or_alive;
+				if ( isset( $rip ) ) echo $rip;
+			?>
 		</div>
 	</div>
 	<div class="characters-description">

--- a/template-parts/content-post_type_characters.php
+++ b/template-parts/content-post_type_characters.php
@@ -83,7 +83,7 @@ $gender_sexuality = lwtv_yikes_chardata( get_the_ID(), 'gender' ) . ' &bull; ' .
 		</div>
 		<div class="card-meta-item">
 			<?php 
-				if ( isset( $dead_or_alive ) ) echo $dead_or_alive;
+				if ( isset( $dead_or_alive ) ) echo $dead_or_alive . '</br>';
 				if ( isset( $rip ) ) echo $rip;
 			?>
 		</div>

--- a/template-parts/content-post_type_shows.php
+++ b/template-parts/content-post_type_shows.php
@@ -155,7 +155,7 @@ if ( $related ) {
 				<ul class="guest-character-list"><?php
 				foreach( $chars_guest as $character ) {
 					
-					$grave = ( get_post_meta( $character['id'], 'lezchars_death_year', true ) )? '<span role="img" aria-label="RIP Tombstone" title="RIP Tombstone" class="charlist-grave-sm">' . lwtv_yikes_symbolicons( 'rest-in-peace.svg', 'fa-times-circle' ) . '</span>' : '';
+					$grave = ( has_term( 'dead', 'lez_cliches' , $the_ID ) )? '<span role="img" aria-label="RIP Tombstone" title="RIP Tombstone" class="charlist-grave-sm">' . lwtv_yikes_symbolicons( 'rest-in-peace.svg', 'fa-times-circle' ) . '</span>' : '';
 					
 					?><li><a href="<?php the_permalink( $character['id'] ); ?>" title="<?php echo get_the_title( $character['id'] ); ?>" ><?php echo get_the_title( $character['id'] ) . ' ' . $grave; ?></a></li><?php
 				}

--- a/template-parts/excerpt-post_type_characters.php
+++ b/template-parts/excerpt-post_type_characters.php
@@ -29,7 +29,7 @@ unset( $shows, $actors, $gender, $sexuality, $cliches, $grave );
 
 // Show a gravestone for recurring characters
 if ( ( $role == 'recurring' && 'post_type_shows' == get_post_type() ) ) {
-	$grave = ( get_post_meta( $the_ID, 'lezchars_death_year', true ) )? '<span role="img" aria-label="RIP Tombstone" title="RIP Tombstone" class="charlist-grave-sm">' . lwtv_yikes_symbolicons( 'rest-in-peace.svg', 'fa-times-circle' ) . '</span>' : '';
+	$grave = ( has_term( 'dead', 'lez_cliches' , $the_ID ) )? '<span role="img" aria-label="RIP Tombstone" title="RIP Tombstone" class="charlist-grave-sm">' . lwtv_yikes_symbolicons( 'rest-in-peace.svg', 'fa-times-circle' ) . '</span>' : '';
 }
 ?>
 


### PR DESCRIPTION
Change how we check if someone is dead to stop Sara from Lance parading all over the place as a dead/not-dead.

Instead of just looking for the year died, we look for the active tag. That way Sara won't be on the dead queers page anymore. Which she shouldn't be.