### PR TITLE
Related Posts and Style

### DIFF
--- a/archive-post_type_actors.php
+++ b/archive-post_type_actors.php
@@ -8,11 +8,11 @@
  */
 
 // Determine icon (Font-Awesome fallback).
-$icon         = lwtv_yikes_symbolicons( 'team.svg', 'fa-users' );
-$count_posts  = facetwp_display( 'counts' );
-$title        = '<span role="img" aria-label="post_type_actors" title="Actors" class="taxonomy-svg actors">' . $icon . '</span>';
-$descriptions = get_option( 'wpseo_titles' );
-$description  = $descriptions['metadesc-ptarchive-post_type_actors'];
+$icon        = lwtv_yikes_symbolicons( 'team.svg', 'fa-users' );
+$count_posts = facetwp_display( 'counts' );
+$actor_title = '<span role="img" aria-label="post_type_actors" title="Actors" class="taxonomy-svg actors">' . $icon . '</span>';
+$seo_descs   = get_option( 'wpseo_titles' );
+$seo_desc    = $seo_descs['metadesc-ptarchive-post_type_actors'];
 
 get_header(); ?>
 
@@ -24,13 +24,13 @@ get_header(); ?>
 					<div class="col-10">
 						<?php the_archive_title( '<h1 class="facetwp-page-title entry-title"><span class="facetwp-title">', '</span>(' . $count_posts . '<span class="facetwp-count"></span>)</h1>' ); ?>
 					</div>
-					<div class="col-2 icon plain"><?php echo lwtv_sanitized( $title ); // WPCS: XSS ok. ?></div>
+					<div class="col-2 icon plain"><?php echo lwtv_sanitized( $actor_title ); // WPCS: XSS ok. ?></div>
 				</div>
 				<div class="row">
 					<div class="col">
 						<div class="archive-description">
 							<?php
-								echo '<p>' . wp_kses_post( $description ) . ' <span class="facetwp-description"></span></p>';
+								echo '<p>' . wp_kses_post( $seo_desc ) . ' <span class="facetwp-description"></span></p>';
 								echo '<p><span class="facetwp-sorted"></span></p>';
 								echo wp_kses_post( facetwp_display( 'selections' ) );
 							?>

--- a/archive-post_type_characters.php
+++ b/archive-post_type_characters.php
@@ -7,11 +7,11 @@
  * @package LezWatch.TV
  */
 
-$icon         = lwtv_yikes_symbolicons( 'contact-card.svg', 'fa-users' );
-$count_posts  = facetwp_display( 'counts' );
-$title        = '<span role="img" aria-label="post_type_characters" title="Characters" class="taxonomy-svg characters">' . $icon . '</span>';
-$descriptions = get_option( 'wpseo_titles' );
-$description  = $descriptions['metadesc-ptarchive-post_type_characters'];
+$icon        = lwtv_yikes_symbolicons( 'contact-card.svg', 'fa-users' );
+$count_posts = facetwp_display( 'counts' );
+$char_title  = '<span role="img" aria-label="post_type_characters" title="Characters" class="taxonomy-svg characters">' . $icon . '</span>';
+$seo_descs   = get_option( 'wpseo_titles' );
+$seo_desc    = $seo_descs['metadesc-ptarchive-post_type_characters'];
 
 get_header(); ?>
 
@@ -23,13 +23,13 @@ get_header(); ?>
 					<div class="col-10">
 						<?php the_archive_title( '<h1 class="facetwp-page-title entry-title"><span class="facetwp-title">', '</span> (' . $count_posts . '<span class="facetwp-count"></span>)</h1>' ); ?>
 					</div>
-					<div class="col-2 icon plain"><?php echo lwtv_sanitized( $title ); // WPCS: XSS ok. ?></div>
+					<div class="col-2 icon plain"><?php echo lwtv_sanitized( $char_title ); // WPCS: XSS ok. ?></div>
 				</div>
 				<div class="row">
 					<div class="col">
 						<div class="archive-description">
 							<?php
-								echo '<p>' . wp_kses_post( $description ) . ' <span class="facetwp-description"></span></p>';
+								echo '<p>' . wp_kses_post( $seo_desc ) . ' <span class="facetwp-description"></span></p>';
 								echo '<p><span class="facetwp-sorted"></span></p>';
 								echo facetwp_display( 'selections' );
 							?>

--- a/inc/lesbians.php
+++ b/inc/lesbians.php
@@ -203,27 +203,33 @@ function lwtv_yikes_tax_archive_title( $location, $posttype, $taxonomy ) {
 			$fa  = 'fa-bell';
 			$svg = $termicon ? $termicon . '.svg' : 'bell.svg';
 			break;
-		case 'lez_gender':
-			$fa  = 'fa-venus';
-			$svg = $termicon ? $termicon . '.svg' : 'venus.svg';
-			break;
-		case 'lez_sexuality':
-			$fa  = 'fa-venus-double';
-			$svg = $termicon ? $termicon . '.svg' : 'venus-double.svg';
-			break;
-		case 'lez_romantic':
-			$fa  = 'fa-heart';
-			$svg = $termicon ? $termicon . '.svg' : 'heart-download.svg';
+		case 'lez_tropes':
+			$fa  = 'fa-pastafarianism';
+			$svg = $termicon ? $termicon . '.svg' : 'octopus.svg';
 			break;
 		case 'lez_formats':
-			$fa  = 'fa-tv';
-			$svg = $termicon ? $termicon . '.svg' : 'tv.svg';
+			$fa  = 'fa-film';
+			$svg = $termicon ? $termicon . '.svg' : 'film-strip.svg';
 			break;
+		case 'lez_genres':
+			$fa  = 'fa-th-large';
+			$svg = $termicon ? $termicon . '.svg' : 'blocks.svg';
+			break;
+		case 'lez_intersections':
+			$fa  = 'fa-flag';
+			$svg = $termicon ? $termicon . '.svg' : 'flag-wave.svg';
+			break;
+		case 'lez_gender':
 		case 'lez_actor_gender':
-			$fa  = 'fa-bug';
-			$svg = 'octopus.svg';
+			$fa  = 'fa-female';
+			$svg = 'female.svg';
 			break;
+		case 'lez_sexuality':
 		case 'lez_actor_sexuality':
+			$fa  = 'fa-venus-double';
+			$svg = 'venus-double.svg';
+			break;
+		case 'lez_romantic':
 			$fa  = 'fa-heartbeat';
 			$svg = 'user-heart.svg';
 			break;
@@ -245,7 +251,7 @@ function lwtv_yikes_tax_archive_title( $location, $posttype, $taxonomy ) {
 			break;
 		default:
 			$fa  = 'fa-square';
-			$svg = $termicon ? $termicon . '.svg' : 'square.svg';
+			$svg = 'square.svg';
 			break;
 	}
 

--- a/template-parts/content-post_type_actors.php
+++ b/template-parts/content-post_type_actors.php
@@ -7,6 +7,11 @@
  * @package LezWatch.TV
  */
 
+// Related Posts
+$slug     = get_post_field( 'post_name', get_post( get_the_ID() ) );
+$get_tags = get_term_by( 'name', $slug, 'post_tag' );
+$related  = LWTV_Related_Posts::are_there_posts( $slug );
+
 // Generate Life Stats
 // Usage: $life
 $life = array();
@@ -146,6 +151,26 @@ $thumb_array       = array(
 </section>
 
 <?php
+// Related Posts
+if ( $related ) {
+	?>
+	<section name="related-posts" id="related-posts" class="showschar-section">
+		<h2>Related Articles</h2>
+		<div class="card-body">
+			<?php
+			echo LWTV_Related_Posts::related_posts( $slug ); // WPCS: XSS okay
+			if ( count( LWTV_Related_Posts::count_related_posts( $slug ) ) > '5' ) {
+				$get_tags = term_exists( $slug, 'post_tag' );
+				if ( ! is_null( $get_tags ) && $get_tags >= 1 ) {
+					echo '<p><a href="' . esc_url( get_tag_link( $get_tags['term_id'] ) ) . '">Read More ...</a></p>';
+				}
+			}
+			?>
+		</div>
+	</section>
+	<?php
+}
+
 // Great big characters section!
 ?>
 <section name="characters" id="characters" class="showschar-section">

--- a/template-parts/content-post_type_shows.php
+++ b/template-parts/content-post_type_shows.php
@@ -7,11 +7,10 @@
  * @package LezWatch.TV
  */
 
-$show_id = $post->ID;
-$slug    = get_post_field( 'post_name', get_post( $show_id ) );
-$term    = term_exists( $slug, 'post_tag' );
-$tag     = get_term_by( 'name', $slug, 'post_tag' );
-$related = LWTV_Related_Posts::are_there_posts( $slug );
+$show_id  = $post->ID;
+$slug     = get_post_field( 'post_name', get_post( $show_id ) );
+$get_tags = get_term_by( 'name', $slug, 'post_tag' );
+$related  = LWTV_Related_Posts::are_there_posts( $slug );
 
 // Microformats Fix.
 lwtv_microformats_fix( $post->ID );
@@ -21,11 +20,14 @@ $thumb_attribution = get_post_meta( get_post_thumbnail_id(), 'lwtv_attribution',
 $thumb_title       = ( empty( $thumb_attribution ) ) ? get_the_title() : get_the_title() . ' &copy; ' . $thumb_attribution;
 
 // Echo the header image.
-the_post_thumbnail('large', array(
-	'class' => 'card-img-top',
-	'alt'   => get_the_title(),
-	'title' => $thumb_title,
-) );
+the_post_thumbnail(
+	'large',
+	array(
+		'class' => 'card-img-top',
+		'alt'   => get_the_title(),
+		'title' => $thumb_title,
+	)
+);
 ?>
 
 <section id="toc" class="toc-container card-body">
@@ -117,9 +119,9 @@ if ( $related ) {
 			<?php
 			echo LWTV_Related_Posts::related_posts( $slug ); // WPCS: XSS okay
 			if ( count( LWTV_Related_Posts::count_related_posts( $slug ) ) > '5' ) {
-				$tag = term_exists( $slug, 'post_tag' );
-				if ( ! is_null( $tag ) && $tag >= 1 ) {
-					echo '<p><a href="' . esc_url( get_tag_link( $tag['term_id'] ) ) . '">Read More ...</a></p>';
+				$get_tags = term_exists( $slug, 'post_tag' );
+				if ( ! is_null( $get_tags ) && $get_tags >= 1 ) {
+					echo '<p><a href="' . esc_url( get_tag_link( $get_tags['term_id'] ) ) . '">Read More ...</a></p>';
 				}
 			}
 			?>


### PR DESCRIPTION
## Related Posts

In order to spread more precious SEO Jews all over posts, we're linking 
back to actors if they're mentioned in posts (see Ali Liebert and Yvonne 
Suhor). This will benefit any interviews we do too!

## Style/Icons 

In order to make ongoing maintenance of genders and sexiualites less 
cranky, we're removing custom icons for gender/sexuality/romantic. 
Currently only the following taxonomies have custom icons:

* Cliches, Genres, Intersections, Tropes, TV Stations

That's it.