### PR TITLE
Namespace Compat

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"cSpell.words": [
+		"lwtv"
+	]
+}

--- a/archive.php
+++ b/archive.php
@@ -19,10 +19,10 @@ if ( is_author() ) {
 	$archive_icon      = get_avatar( get_the_author_meta( 'user_email' ), 96, '', 'Avatar for author ' . get_the_author_meta( 'display_name' ) );
 	$archive_subheader = lwtv_author_social( $author );
 	$archive_details   = lwtv_author_favourite_shows( $author );
-} elseif ( is_tag() && class_exists( 'LWTV_CPTs_Related_Posts' ) ) {
+} elseif ( is_tag() ) {
 	$tag_id          = get_queried_object()->term_id;
 	$archive_icon    = lwtv_symbolicons( 'tag.svg', 'fa-tag' );
-	$archive_details = ( new LWTV_CPTs_Related_Posts() )->related_archive_header( $tag_id );
+	$archive_details = lwtv_plugin()->get_related_archive_header( $tag_id );
 }
 
 get_header(); ?>

--- a/inc/lesbians.php
+++ b/inc/lesbians.php
@@ -352,7 +352,7 @@ function lwtv_symbolicons( $svg, $fa ) {
 	if ( empty( $symbolicon ) ) {
 		$symbolicon = '<span class="symbolicon" role="img"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="spinner" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-spinner fa-w-16 fa-3x"><path fill="currentColor" d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z" class=""></path></svg></span>';
 	}
-	return $return;
+	return $symbolicon;
 }
 
 /**

--- a/inc/lesbians.php
+++ b/inc/lesbians.php
@@ -198,11 +198,9 @@ add_action( 'pre_get_posts', 'lwtv_yikes_character_archive_query' );
  * @return string $title_adjustment -- Adjusted title.
  */
 function lwtv_yikes_tax_archive_title( $location, $post_type, $taxonomy ) {
-	if ( class_exists( 'LWTV_Theme_Taxonomy_Archive_Title' ) ) {
-		$title_adjustment = ( new LWTV_Theme_Taxonomy_Archive_Title() )->make( $location, $post_type, $taxonomy );
-	}
+	$title_adjustment = lwtv_plugin()->get_tax_archive_title( $location, $post_type, $taxonomy );
 
-	if ( isset( $title_adjustment ) && ! empty( $title_adjustment ) ) {
+	if ( ! empty( $title_adjustment ) ) {
 		return $title_adjustment;
 	}
 }
@@ -237,11 +235,9 @@ if ( is_search() ) {
  * @return void
  */
 function lwtv_yikes_show_star( $show_id ) {
-	if ( class_exists( 'LWTV_Theme_Show_Stars' ) ) {
-		$star = ( new LWTV_Theme_Show_Stars() )->make( $show_id );
-	}
+	$star = lwtv_plugin()->get_show_stars( $show_id );
 
-	if ( isset( $star ) && ! empty( $star ) ) {
+	if ( ! empty( $star ) ) {
 		return $star;
 	}
 }
@@ -255,11 +251,9 @@ function lwtv_yikes_show_star( $show_id ) {
  * @return void
  */
 function lwtv_yikes_content_warning( $show_id ) {
-	if ( isset( $show_id ) && class_exists( 'LWTV_Theme_Content_Warning' ) ) {
-		$warning_array = ( new LWTV_Theme_Content_Warning() )->make( $show_id );
-	}
+	$warning_array = lwtv_plugin()->get_show_content_warning( $show_id );
 
-	if ( isset( $warning_array ) && is_array( $warning_array ) ) {
+	if ( is_array( $warning_array ) && ! empty( $warning_array ) ) {
 		return $warning_array;
 	}
 }
@@ -275,14 +269,7 @@ function lwtv_yikes_content_warning( $show_id ) {
  * @return void
  */
 function lwtv_yikes_chardata( $the_id, $data ) {
-
-	if ( isset( $the_id ) && class_exists( 'LWTV_Theme_Data_Character' ) ) {
-		$character_data = ( new LWTV_Theme_Data_Character() )->make( $the_id, $data );
-	}
-
-	if ( isset( $character_data ) ) {
-		return $character_data;
-	}
+	return lwtv_plugin()->get_character_data( $the_id, $data );
 }
 
 /**
@@ -293,16 +280,16 @@ function lwtv_yikes_chardata( $the_id, $data ) {
  * @access public
  * @param mixed $the_id: the actor post ID
  * @param mixed $data:
- * @return void
+ * @return mixed
  */
 function lwtv_yikes_actordata( $the_id, $data ) {
-	if ( isset( $the_id ) && class_exists( 'LWTV_Theme_Data_Actor' ) ) {
-		$actor_data = ( new LWTV_Theme_Data_Actor() )->make( $the_id, $data );
+	$actor_data = array();
+
+	if ( isset( $the_id ) ) {
+		$actor_data = lwtv_plugin()->get_actor_data( $the_id, $data );
 	}
 
-	if ( isset( $actor_data ) ) {
-		return $actor_data;
-	}
+	return $actor_data;
 }
 
 /**
@@ -313,11 +300,7 @@ function lwtv_yikes_actordata( $the_id, $data ) {
  * @return bool
  */
 function lwtv_yikes_is_queer( $the_id ) {
-	$is_queer = false;
-	if ( method_exists( 'LWTV_Queery_Is_Actor_Queer', 'make' ) ) {
-		$is_queer = ( 'yes' === ( new LWTV_Queery_Is_Actor_Queer() )->make( $the_id ) ) ? true : false;
-	}
-
+	$is_queer = ( 'yes' === lwtv_plugin()->is_actor_queer( $the_id ) ) ? true : false;
 	return $is_queer;
 }
 
@@ -329,10 +312,7 @@ function lwtv_yikes_is_queer( $the_id ) {
  * @return bool
  */
 function lwtv_yikes_is_birthday( $the_id ) {
-	$happy_birthday = false;
-	if ( class_exists( 'LWTV_Theme_Actor_Birthday' ) ) {
-		$happy_birthday = ( new LWTV_Theme_Actor_Birthday() )->make( $the_id );
-	}
+	$happy_birthday = lwtv_plugin()->is_actor_birthday( $the_id );
 	return $happy_birthday;
 }
 
@@ -367,10 +347,10 @@ function lwtv_microformats_fix( $post_id ) {
  * @return string      Whatever we end up with
  */
 function lwtv_symbolicons( $svg, $fa ) {
-	if ( method_exists( 'LWTV_Features', 'symbolicons' ) ) {
-		$return = ( new LWTV_Features() )->symbolicons( $svg, $fa );
-	} else {
-		$return = '<span class="symbolicon" role="img"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="spinner" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-spinner fa-w-16 fa-3x"><path fill="currentColor" d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z" class=""></path></svg></span>';
+	$symbolicon = lwtv_plugin()->get_symbolicon( $svg, $fa );
+
+	if ( empty( $symbolicon ) ) {
+		$symbolicon = '<span class="symbolicon" role="img"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="spinner" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-spinner fa-w-16 fa-3x"><path fill="currentColor" d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z" class=""></path></svg></span>';
 	}
 	return $return;
 }
@@ -382,9 +362,7 @@ function lwtv_symbolicons( $svg, $fa ) {
  * @return mixed   number or array listing the characters
  */
 function lwtv_list_characters( $post_id, $output ) {
-	if ( class_exists( 'LWTV_Theme_List_Characters' ) ) {
-		return ( new LWTV_Theme_List_Characters() )->make( $post_id, $output );
-	}
+	return lwtv_plugin()->get_list_characters( $post_id, $output );
 }
 
 /**
@@ -395,11 +373,7 @@ function lwtv_list_characters( $post_id, $output ) {
  * @return array           List of all the characters
  */
 function lwtv_get_chars_for_show( $post_id, $count, $roll ) {
-	$return = '';
-	if ( method_exists( 'LWTV_CPT_Characters', 'get_chars_for_show' ) ) {
-		$return = ( new LWTV_CPT_Characters() )->get_chars_for_show( $post_id, $count, $roll );
-	}
-	return $return;
+	return lwtv_plugin()->get_chars_for_show( $post_id, $count, $roll );
 }
 
 /**
@@ -422,14 +396,12 @@ function lwtv_last_updated_date( $post_id ) {
  * @return n/a
  */
 function lwtv_last_death() {
-	$return = '<p>The LezWatch.TV API is temporarily unavailable.</p>';
-	if ( class_exists( 'LWTV_Rest_API_BYQ' ) ) {
-		$last_death = ( new LWTV_Rest_API_BYQ() )->last_death();
-		if ( '' !== $last_death ) {
-			$return  = '<p>' . sprintf( 'It has been %s since the last queer female, non-binary, or transgender death on television', '<strong>' . human_time_diff( $last_death['died'], (int) wp_date( 'U' ) ) . '</strong> ' );
-			$return .= ': <span><a href="' . $last_death['url'] . '">' . $last_death['name'] . '</a></span> - ' . gmdate( 'F j, Y', $last_death['died'] ) . '</p>';
-			// NOTE! Add `class="hidden-death"` to the span above if you want to blur the display of the last death.
-		}
+	$return     = '<p>The LezWatch.TV API is temporarily unavailable.</p>';
+	$last_death = lwtv_plugin()->get_json_last_death();
+	if ( '' !== $last_death ) {
+		$return  = '<p>' . sprintf( 'It has been %s since the last queer female, non-binary, or transgender death on television', '<strong>' . human_time_diff( $last_death['died'], (int) wp_date( 'U' ) ) . '</strong> ' );
+		$return .= ': <span><a href="' . $last_death['url'] . '">' . $last_death['name'] . '</a></span> - ' . gmdate( 'F j, Y', $last_death['died'] ) . '</p>';
+		// NOTE! Add `class="hidden-death"` to the span above if you want to blur the display of the last death.
 	}
 
 	$return = '<div class="lezwatchtv last-death">' . $return . '</div>';
@@ -444,11 +416,7 @@ function lwtv_last_death() {
  * @return string $details Output of author social.
  */
 function lwtv_author_social( $author ) {
-	$return = '';
-	if ( class_exists( 'LWTV_Theme_Data_Author' ) ) {
-		$return = ( new LWTV_Theme_Data_Author() )->make( $author, 'social' );
-	}
-	return $return;
+	return lwtv_plugin()->get_author_social( $author );
 }
 
 /**
@@ -458,9 +426,5 @@ function lwtv_author_social( $author ) {
  * @return string $details Output of author fav shows.
  */
 function lwtv_author_favourite_shows( $author ) {
-	$return = '';
-	if ( class_exists( 'LWTV_Theme_Data_Author' ) ) {
-		$return = ( new LWTV_Theme_Data_Author() )->make( $author, 'favorite_shows' );
-	}
-	return $return;
+	return lwtv_plugin()->get_author_favorite_shows( $author );
 }

--- a/page-templates/statistics.php
+++ b/page-templates/statistics.php
@@ -14,14 +14,7 @@ $validstat = array( 'death', 'characters', 'shows', 'main', 'actors', 'nations',
 $statstype = ( isset( $wp_query->query['statistics'] ) && in_array( $wp_query->query['statistics'], $validstat, true ) ) ? esc_attr( $wp_query->query['statistics'] ) : 'main';
 
 // Defaults:
-$theme_defaults = array(
-	'image' => lwtv_symbolicons( 'graph-bar.svg', 'fa-chart-area' ),
-	'intro' => '',
-);
-
-if ( class_exists( 'LWTV_Theme_Stats_Symbolicon' ) ) {
-	$theme_defaults = ( new LWTV_Theme_Stats_Symbolicon() )->make( $statstype );
-}
+$theme_defaults = lwtv_plugin()->get_stats_symbolicon( $statstype );
 
 $image = '<span role="img" aria-label="statistics" title="Statistics" class="taxonomy-svg statistics">' . $theme_defaults['image'] . '</span>';
 
@@ -73,13 +66,14 @@ get_header(); ?>
 								the_content();
 							}
 
-							if ( method_exists( 'LWTV_Statistics_Gutenberg_SSR', 'statistics' ) ) {
-								$attributes = array(
-									'page' => $statstype,
-								);
+							$attributes = array(
+								'page' => $statstype,
+							);
+							$stats      = lwtv_plugin()->generate_stats_block( $attributes );
 
+							if ( ! empty( $stats ) ) {
 								// phpcs:ignore WordPress.Security.EscapeOutput
-								echo ( new LWTV_Statistics_Gutenberg_SSR() )->statistics( $attributes );
+								echo $stats;
 							} else {
 								echo '<p>After this maintenance, statistics will be right back!</p>';
 							}

--- a/page-templates/thisyear.php
+++ b/page-templates/thisyear.php
@@ -54,10 +54,8 @@ get_header();
 					<div id="content" class="site-content clearfix" role="main">
 						<div class="thisyear">
 							<?php
-							if ( method_exists( 'LWTV_This_Year_Display', 'make' ) ) {
-								// phpcs:ignore WordPress.Security.EscapeOutput
-								echo ( new LWTV_This_Year_Display() )->make( $thisyear );
-							}
+							// phpcs:ignore WordPress.Security.EscapeOutput
+							echo lwtv_plugin()->get_this_year_display( $thisyear );
 							?>
 						</div>
 					</div><!-- #content -->

--- a/rss-otd.php
+++ b/rss-otd.php
@@ -21,24 +21,24 @@ echo '<?xml version="1.0" encoding="' . esc_attr( get_option( 'blog_charset' ) )
 	<title>LezWatch.TV Of The Day - Feed</title>
 	<atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
 	<link><?php echo esc_url( bloginfo_rss( 'url' ) ); ?></link>
-	<description>Keep up to date with the latest featured characters and shows! Updated daily.</description>
+	<description>Keep up to date with the latest featured characters and shows! Updated twice a day.</description>
 	<lastBuildDate>
-		<?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', ( new LWTV_Of_The_Day_RSS() )->last_build(), false ) ); ?>
+		<?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', lwtv_plugin()->get_rss_otd_last_build(), false ) ); ?>
 	</lastBuildDate>
 	<language>en-US</language>
 	<sy:updatePeriod><?php echo esc_html( apply_filters( 'rss_update_period', 'hourly' ) ); ?></sy:updatePeriod>
 	<sy:updateFrequency><?php echo esc_html( apply_filters( 'rss_update_frequency', '1' ) ); ?></sy:updateFrequency>
-	<generator>https://wordpress.org/?v=<?php echo floatval( ( new LWTV_Of_The_Day_RSS() )->return_wp_version() ); ?></generator>
+	<generator>https://wordpress.org/?v=<?php echo floatval( lwtv_plugin()->get_wp_version() ); ?></generator>
 	<image>
 		<url><?php echo esc_url( get_option( 'jetpack_site_icon_url' ) ); ?></url>
 		<title>LezWatch.TV Of The Day - Feed</title>
 		<link><?php echo esc_url( get_site_url() ); ?>/feed/otd/</link>
 		<width>32</width>
 		<height>32</height>
-	</image> 
+	</image>
 	<?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	( new LWTV_Of_The_Day_RSS() )->rss_feed();
+	lwtv_plugin()->get_rss_otd_feed();
 	?>
 </channel>
 </rss>

--- a/template-parts/content-post_type_actors.php
+++ b/template-parts/content-post_type_actors.php
@@ -14,12 +14,10 @@ $get_tags = get_term_by( 'name', $slug, 'post_tag' );
 
 // This just gets the numbers of all characters and how many are dead.
 $all_chars     = lwtv_yikes_actordata( $the_id, 'characters' );
-$havecharcount = count( $all_chars );
+$havecharcount = ( is_array( $all_chars ) ) ? count( $all_chars ) : 0;
 $havedeadcount = count( lwtv_yikes_actordata( $the_id, 'dead' ) );
 
-if ( method_exists( 'LWTV_CPTs_Related_Posts', 'are_there_posts' ) ) {
-	$related = ( new LWTV_CPTs_Related_Posts() )->are_there_posts( $slug );
-}
+$related = lwtv_plugin()->has_cpt_related_posts( $slug );
 
 // Generate Life Stats.
 // Usage: $life.
@@ -32,7 +30,7 @@ if ( isset( $barr ) && isset( $barr[1] ) && isset( $barr[2] ) && checkdate( (int
 	$get_birth    = new DateTime( $born );
 	$age          = lwtv_yikes_actordata( $the_id, 'age', true );
 	$life['born'] = date_format( $get_birth, 'F j, Y' );
-	$life['age']  = $age->format( '%Y years old' );
+	$life['age']  = ( is_object( $age ) ) ? $age->format( '%Y years old' ) : '';
 }
 $died = get_post_meta( $the_id, 'lezactors_death', true );
 if ( ! empty( $died ) ) {
@@ -253,7 +251,7 @@ if ( isset( $related ) && $related ) {
 		<div class="card-body">
 			<?php
 			if ( method_exists( 'LWTV_CPTs_Related_Posts', 'related_posts' ) && method_exists( 'LWTV_CPTs_Related_Posts', 'count_related_posts' ) ) {
-				echo ( new LWTV_CPTs_Related_Posts() )->related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
+				echo lwtv_plugin()->get_cpt_related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 			?>
 		</div>
@@ -299,13 +297,14 @@ if ( 0 !== $havecharcount ) {
 			<div class="card-meta">
 				<div class="card-meta-item">
 					<?php
-					if ( method_exists( 'LWTV_Statistics_Gutenberg_SSR', 'statistics' ) ) {
-						$attributes = array(
-							'posttype' => get_post_type(),
-						);
+					$attributes = array(
+						'posttype' => get_post_type(),
+					);
+					$stats      = lwtv_plugin()->generate_stats_block_actor( $attributes );
 
+					if ( ! empty( $stats ) ) {
 						// phpcs:ignore WordPress.Security.EscapeOutput
-						echo ( new LWTV_Statistics_Gutenberg_SSR() )->mini_stats( $attributes );
+						echo $stats;
 					} else {
 						echo '<p>After this maintenance, statistics will be right back!</p>';
 					}

--- a/template-parts/content-post_type_shows.php
+++ b/template-parts/content-post_type_shows.php
@@ -10,8 +10,8 @@
 $show_id        = $post->ID;
 $slug           = get_post_field( 'post_name', get_post( $show_id ) );
 $get_tags       = get_term_by( 'name', $slug, 'post_tag' );
-$related        = ( new LWTV_CPTs_Related_Posts() )->are_there_posts( $slug );
-$rpbt_shortcode = ( new LWTV_Shows_Like_This() )->make( $show_id );
+$related        = lwtv_plugin()->has_cpt_related_posts( $slug );
+$rpbt_shortcode = lwtv_plugin()->get_shows_like_this_show( $show_id );
 
 // Microformats Fix.
 lwtv_microformats_fix( $post->ID );
@@ -86,7 +86,7 @@ if ( is_array( $warning ) && 'none' !== $warning['card'] ) {
 <?php
 // Ways to Watch section (yes all ways-to-watch URLs are in a badly named post_meta).
 if ( ( get_post_meta( $show_id, 'lezshows_affiliate', true ) ) ) {
-	echo '<section id="affiliate-watch-link" class="affiliate-watch-container">' . ( new LWTV_Theme_Ways_To_Watch() )->ways_to_watch( $show_id ) . '</section>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo '<section id="affiliate-watch-link" class="affiliate-watch-container">' . lwtv_plugin()->get_ways_to_watch( $show_id ) . '</section>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 ?>
 
@@ -129,7 +129,7 @@ if ( $related ) {
 		<div class="container"><div class="card-body">
 			<?php
 			if ( method_exists( 'LWTV_CPTs_Related_Posts', 'related_posts' ) && method_exists( 'LWTV_CPTs_Related_Posts', 'count_related_posts' ) ) {
-				echo ( new LWTV_CPTs_Related_Posts() )->related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
+				echo lwtv_plugin()->get_cpt_related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 			?>
 		</div></div>
@@ -156,8 +156,8 @@ if ( $related ) {
 
 		// If havecharcount and chars_total are different, rerun the call.
 		if ( $chars_total !== $havecharcount ) {
-			$havecharcount = ( new LWTV_CPT_Characters() )->list_characters( $show_id, 'count' );
-			$havedeadcount = ( new LWTV_CPT_Characters() )->list_characters( $show_id, 'dead' );
+			$havecharcount = lwtv_plugin()->get_characters_list( $show_id, 'count' );
+			$havedeadcount = lwtv_plugin()->get_characters_list( $show_id, 'dead' );
 		}
 
 		if ( empty( $havecharcount ) || '0' === $havecharcount ) {

--- a/template-parts/embed-content-post_type_shows.php
+++ b/template-parts/embed-content-post_type_shows.php
@@ -17,7 +17,7 @@
 		border: 1px solid #d1548e;
 		color: #222;
 		display: grid;
-		grid-template-areas: 
+		grid-template-areas:
 		"title title"
 		"image details"
 		"excerpt excerpt"
@@ -75,7 +75,7 @@
 		align-items: center;
 		grid-area: footer;
 		display: grid;
-		grid-template-areas: 
+		grid-template-areas:
 			"site flag";
 		grid-template-columns: 50% 50%;
 		margin:  0;
@@ -198,7 +198,7 @@
 				// Next Episode (if none, show 'aired on...')
 				$on_air = get_post_meta( get_the_ID(), 'lezshows_on_air', true );
 				if ( 'yes' === $on_air ) {
-					$tvmaze = ( new LWTV_Whats_On_JSON() )->whats_on_show( get_the_ID() );
+					$tvmaze = lwtv_plugin()->get_whats_on_show( get_the_ID() );
 					echo '<strong>Next Episode:</strong> ';
 					if ( isset( $tvmaze['next'] ) ) {
 						echo wp_kses_post( $tvmaze['next'] );
@@ -222,7 +222,7 @@
 
 		<div class="wp-embed-footer">
 			<div class="wp-embed-site">
-				<?php the_embed_site_title(); ?>				
+				<?php the_embed_site_title(); ?>
 			</div>
 
 			<div class="wp-embed-flag">

--- a/template-parts/sidebar-post_type_shows.php
+++ b/template-parts/sidebar-post_type_shows.php
@@ -65,10 +65,10 @@ $alt_names    = ( get_post_meta( $show_id, 'lezshows_show_names', true ) ) ? get
 				}
 
 				// Collect all the scores.
-				$scores = ( new LWTV_Grading() )->all_scores( $show_id );
+				$scores = lwtv_plugin()->get_all_scores( $show_id );
 				if ( isset( $scores ) ) {
 					echo '<center><h4>Show Scores</h4></center>';
-					( new LWTV_Grading() )->display( $scores );
+					lwtv_plugin()->display_scores( $scores );
 				}
 				?>
 			</div>
@@ -87,7 +87,7 @@ $alt_names    = ( get_post_meta( $show_id, 'lezshows_show_names', true ) ) ? get
 				// If the show is on air, we'll see when it airs next!
 				$on_air = get_post_meta( $show_id, 'lezshows_on_air', true );
 				if ( 'yes' === $on_air ) {
-					( new LWTV_Theme_TVMaze() )->episodes( $show_id );
+					lwtv_plugin()->get_tvmaze_episodes( $show_id );
 				}
 
 				$formats = get_the_terms( $show_id, 'lez_formats' );


### PR DESCRIPTION
Required as soon as https://github.com/LezWatch/lwtv-plugin/pull/391 is done.

This changes the calls to the wrappers, so this:

`( new LWTV_CPTs_Related_Posts() )->related_archive_header( $tag_id );`

Becomes this:

`lwtv_plugin()->get_related_archive_header( $tag_id );`

Now you don't have to know what class/namespace is what!