### PR TITLE
NameSpace Compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"cSpell.words": [
+		"lwtv"
+	]
+}

--- a/404.php
+++ b/404.php
@@ -13,7 +13,7 @@ get_header();
 		<div class="container">
 			<section class="archive-header">
 				<div class="row">
-					<div class="col-10"><h1 class="entry-title"><?php esc_attr_e( 'Oops! This isn\'t the page you thought it was.', 'yikes_starter' ); ?></h1></div>
+					<div class="col-10"><h1 class="entry-title"><?php esc_attr_e( 'Oops! This isn\'t the page you thought it was.', 'lwtv-underscores' ); ?></h1></div>
 					<div class="col-2 icon plain"><span role="img" aria-label="404" title="404 - Page Not Found" class="taxonomy-svg 404"><?php echo lwtv_symbolicons( 'easter-egg-alt.svg', 'fa-gift' ); ?></span></div>
 				</div>
 			</section><!-- .archive-header -->
@@ -30,7 +30,7 @@ get_header();
 						<article id="post-0" class="post not-found">
 							<div class="entry-content clearfix">
 								<p><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/images/rose.gif" alt="Rose revealing herself from Jane the Virgin" class="alignleft"/></p>
-								<p><?php esc_attr_e( 'Sorry, there is no page with this address. Please try again or use the search below.', 'yikes_starter' ); ?></p>
+								<p><?php esc_attr_e( 'Sorry, there is no page with this address. Please try again or use the search below.', 'lwtv-underscores' ); ?></p>
 
 								<div class="row g-0">
 									<div class="col-sm-8">

--- a/archive.php
+++ b/archive.php
@@ -7,9 +7,10 @@
 
 // Defaults
 $current_archive   = get_queried_object();
+$current_count     = ( isset( $current_archive->count ) ) ? $current_archive->count : 0;
 $archive_icon      = lwtv_symbolicons( 'newspaper.svg', 'fa-newspaper' );
 $archive_details   = '';
-$archive_subheader = '<span class="post-count">' . sprintf( _n( '%s article', '%s articles', $current_archive->count ), number_format_i18n( $current_archive->count ) ) . '</span>';
+$archive_subheader = '<span class="post-count">' . sprintf( _n( '%s article', '%s articles', $current_count ), number_format_i18n( $current_count ) ) . '</span>';
 
 // Custom header info
 if ( is_author() ) {

--- a/archive.php
+++ b/archive.php
@@ -19,10 +19,10 @@ if ( is_author() ) {
 	$archive_icon      = get_avatar( get_the_author_meta( 'user_email' ), 96, '', 'Avatar for author ' . get_the_author_meta( 'display_name' ) );
 	$archive_subheader = lwtv_author_social( $author );
 	$archive_details   = lwtv_author_favourite_shows( $author );
-} elseif ( is_tag() && class_exists( 'LWTV_CPTs_Related_Posts' ) ) {
+} elseif ( is_tag() ) {
 	$tag_id          = get_queried_object()->term_id;
 	$archive_icon    = lwtv_symbolicons( 'tag.svg', 'fa-tag' );
-	$archive_details = ( new LWTV_CPTs_Related_Posts() )->related_archive_header( $tag_id );
+	$archive_details = lwtv_plugin()->get_related_archive_header( $tag_id );
 }
 
 get_header(); ?>

--- a/attachment.php
+++ b/attachment.php
@@ -14,7 +14,7 @@ get_header(); ?>
 				<div class="row">
 					<div class="col-10">
 						<h1 class="entry-title">
-							<?php esc_attr_e( 'Oops! This isn\'t the page you thought it was.', 'yikes_starter' ); ?>
+							<?php esc_attr_e( 'Oops! This isn\'t the page you thought it was.', 'lwtv-underscores' ); ?>
 						</h1>
 					</div>
 					<div class="col-2 icon plain">
@@ -35,7 +35,7 @@ get_header(); ?>
 						<article id="post-0" class="post not-found">
 							<div class="entry-content clearfix">
 								<p><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/images/rose.gif" alt="Rose revealing herself from Jane the Virgin" class="alignleft"/></p>
-								<p><?php esc_attr_e( 'Sorry, there is no page with this address. Please try again or use the search below.', 'yikes_starter' ); ?></p>
+								<p><?php esc_attr_e( 'Sorry, there is no page with this address. Please try again or use the search below.', 'lwtv-underscores' ); ?></p>
 
 								<div class="row g-0">
 									<div class="col-sm-8">

--- a/comments.php
+++ b/comments.php
@@ -28,7 +28,7 @@ if ( post_password_required() ) {
 			<?php
 				// phpcs:disable
 				printf(
-					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'yikes_starter' ) ),
+					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'lwtv-underscores' ) ),
 					number_format_i18n( get_comments_number() ),
 					'<span>' . get_the_title() . '</span>'
 				);
@@ -38,11 +38,11 @@ if ( post_password_required() ) {
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through? ?>
 		<nav id="comment-nav-above" class="navigation comment-navigation" role="navigation">
-			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'yikes_starter' ); ?></h2>
+			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'lwtv-underscores' ); ?></h2>
 			<div class="nav-links">
 
-				<div class="nav-previous"><?php previous_comments_link( esc_html__( 'Older Comments', 'yikes_starter' ) ); ?></div>
-				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments', 'yikes_starter' ) ); ?></div>
+				<div class="nav-previous"><?php previous_comments_link( esc_html__( 'Older Comments', 'lwtv-underscores' ) ); ?></div>
+				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments', 'lwtv-underscores' ) ); ?></div>
 
 			</div><!-- .nav-links -->
 		</nav><!-- #comment-nav-above -->
@@ -67,11 +67,11 @@ if ( post_password_required() ) {
 			// Are there comments to navigate through?
 			?>
 		<nav id="comment-nav-below" class="navigation comment-navigation" role="navigation">
-			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'yikes_starter' ); ?></h2>
+			<h2 class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'lwtv-underscores' ); ?></h2>
 			<div class="nav-links">
 
-				<div class="nav-previous"><?php previous_comments_link( esc_html__( 'Older Comments', 'yikes_starter' ) ); ?></div>
-				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments', 'yikes_starter' ) ); ?></div>
+				<div class="nav-previous"><?php previous_comments_link( esc_html__( 'Older Comments', 'lwtv-underscores' ) ); ?></div>
+				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments', 'lwtv-underscores' ) ); ?></div>
 
 			</div><!-- .nav-links -->
 		</nav><!-- #comment-nav-below -->
@@ -83,7 +83,7 @@ if ( post_password_required() ) {
 	// If comments are closed and there are comments, let's leave a little note, shall we?
 	if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
 		?>
-		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'yikes_starter' ); ?></p>
+		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'lwtv-underscores' ); ?></p>
 		<?php
 	endif;
 

--- a/content.php
+++ b/content.php
@@ -29,10 +29,10 @@
 	<?php } else { ?>
 		<div class="entry-content">
 			<?php
-				the_content( esc_attr__( 'Continue reading <span class="meta-nav">&rarr;</span>', 'yikes_starter' ) );
+				the_content( esc_attr__( 'Continue reading <span class="meta-nav">&rarr;</span>', 'lwtv-underscores' ) );
 				wp_link_pages(
 					array(
-						'before' => '<div class="page-links">' . esc_attr__( 'Pages:', 'yikes_starter' ),
+						'before' => '<div class="page-links">' . esc_attr__( 'Pages:', 'lwtv-underscores' ),
 						'after'  => '</div>',
 					)
 				);
@@ -44,7 +44,7 @@
 		<?php
 		if ( 'post' === get_post_type() ) {
 			/* translators: used between list items, there is a space after the comma */
-			$categories_list = get_the_category_list( esc_attr__( ', ', 'yikes_starter' ) );
+			$categories_list = get_the_category_list( esc_attr__( ', ', 'lwtv-underscores' ) );
 			if ( $categories_list && yikes_starter_categorized_blog() ) {
 				?>
 				<span class="cat-links">
@@ -53,7 +53,7 @@
 				<?php
 			}
 
-			$tags_list = get_the_tag_list( '', esc_attr__( ', ', 'yikes_starter' ) );
+			$tags_list = get_the_tag_list( '', esc_attr__( ', ', 'lwtv-underscores' ) );
 
 			if ( $tags_list ) {
 				?>
@@ -67,12 +67,12 @@
 		if ( ! post_password_required() && ( comments_open() || '0' !== get_comments_number() ) ) {
 			?>
 			<span class="comments-link">
-				<?php comments_popup_link( esc_attr__( 'Leave a comment', 'yikes_starter' ), esc_attr__( '1 Comment', 'yikes_starter' ), esc_attr__( '% Comments', 'yikes_starter' ) ); ?>
+				<?php comments_popup_link( esc_attr__( 'Leave a comment', 'lwtv-underscores' ), esc_attr__( '1 Comment', 'lwtv-underscores' ), esc_attr__( '% Comments', 'lwtv-underscores' ) ); ?>
 			</span>
 			<?php
 		}
 
-		edit_post_link( esc_attr__( 'Edit', 'yikes_starter' ), '<div class="edit-link">' . lwtv_symbolicons( 'pencil.svg', 'fa-pencil-alt' ), '</div>' );
+		edit_post_link( esc_attr__( 'Edit', 'lwtv-underscores' ), '<div class="edit-link">' . lwtv_symbolicons( 'pencil.svg', 'fa-pencil-alt' ), '</div>' );
 		?>
 	</footer><!-- .entry-meta -->
 </article><!-- #post-## -->

--- a/functions.php
+++ b/functions.php
@@ -5,10 +5,26 @@
  * @package YIKES Starter
  */
 
+/**
+ * Catch for if the plugin is missing, because we really, really,
+ * need it.
+ */
+if ( ! function_exists( 'lwtv_plugin' ) ) {
+	add_action( 'admin_notices', 'lwtv_admin_notice_missing_plugin' );
+}
+
+function lwtv_admin_notice_missing_plugin() {
+	?>
+	<div class="notice notice-error is-dismissible">
+		<p><?php esc_html_e( 'Error! The LWTV Plugin is missing. Please go grab an admin because everything will break.', 'lwtv-underscores' ); ?></p>
+	</div>
+	<?php
+}
+
 // Versioning for efficient developers.
 if ( ! defined( 'LWTV_THEME_VERSION' ) ) {
 	$versions = array(
-		'lwtv-underscores' => '4.0.1',    // Bump this any time you make serious CSS changes.
+		'lwtv-underscores' => '6.0.0',    // Bump this any time you make serious CSS changes.
 		'font-awesome'     => '6.4.2',    // Bump when you update Font Awesome.
 		'bootstrap'        => '5.3.2',    // Bump when you update bootstrap.
 		'lwtv-blocks'      => '1.0.0',    // Bump when you update the blocks.
@@ -30,11 +46,11 @@ if ( ! isset( $content_width ) ) {
 
 // YIKES Setup theme constants These will be used for server and web paths.
 // so we don't have to reference functions every time.
-if ( ! defined( 'YKS_THEME_PATH' ) ) {
-	define( 'YKS_THEME_PATH', get_stylesheet_directory() );
+if ( ! defined( 'LWTV_THEME_PATH' ) ) {
+	define( 'LWTV_THEME_PATH', get_stylesheet_directory() );
 }
-if ( ! defined( 'YKS_THEME_URL' ) ) {
-	define( 'YKS_THEME_URL', trailingslashit( get_stylesheet_directory_uri() ) );
+if ( ! defined( 'LWTV_THEME_URL' ) ) {
+	define( 'LWTV_THEME_URL', trailingslashit( get_stylesheet_directory_uri() ) );
 }
 
 /**
@@ -45,7 +61,6 @@ function yikes_starter_blog_page_title() {
 		return get_the_title( get_option( 'page_for_posts' ) );
 	}
 }
-
 
 /**
  * Excerpts
@@ -103,7 +118,6 @@ add_image_size( 'character-img', 350, 412, true );
 add_image_size( 'show-img', 960, 400, true );
 add_image_size( 'postloop-img', 525, 300, true );
 
-
 /**
  * Comments
  */
@@ -111,8 +125,9 @@ require_once 'inc/walker-comment.php';
 
 /**
  * Authors
+ *
+ * Add bio box.
  */
-// Author bio box.
 require_once 'inc/author-box.php';
 
 /**
@@ -136,7 +151,6 @@ function yikes_archive_title( $title ) {
 
 	return $title;
 }
-
 add_filter( 'get_the_archive_title', 'yikes_archive_title' );
 
 /**
@@ -157,8 +171,8 @@ if ( ! function_exists( 'yikes_starter_setup' ) ) {
 		 * Set up Nav menus */
 		register_nav_menus(
 			array(
-				'primary'     => __( 'Primary Menu', 'yikes_starter' ),
-				'social_menu' => __( 'Social Menu', 'yikes_starter' ),
+				'primary'     => __( 'Primary Menu', 'lwtv-underscores' ),
+				'social_menu' => __( 'Social Menu', 'lwtv-underscores' ),
 			)
 		);
 
@@ -207,7 +221,7 @@ function yikes_starter_widgets_init() {
 	// Home Sidebar.
 	register_sidebar(
 		array(
-			'name'          => __( 'Home Page Sidebar', 'yikes_starter' ),
+			'name'          => __( 'Home Page Sidebar', 'lwtv-underscores' ),
 			'id'            => 'sidebar-1',
 			'description'   => 'The sidebar for the home page',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -219,7 +233,7 @@ function yikes_starter_widgets_init() {
 	// Sub Page Sidebar.
 	register_sidebar(
 		array(
-			'name'          => __( 'Sub Page Sidebar', 'yikes_starter' ),
+			'name'          => __( 'Sub Page Sidebar', 'lwtv-underscores' ),
 			'id'            => 'sidebar-2',
 			'description'   => 'The sidebar for sub pages',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -231,7 +245,7 @@ function yikes_starter_widgets_init() {
 	// Footer Widget 1.
 	register_sidebar(
 		array(
-			'name'          => __( 'Footer Widget Area One', 'yikes_starter' ),
+			'name'          => __( 'Footer Widget Area One', 'lwtv-underscores' ),
 			'id'            => 'footer-1',
 			'description'   => 'The first footer widget area.',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -243,7 +257,7 @@ function yikes_starter_widgets_init() {
 	// Footer Widget 2.
 	register_sidebar(
 		array(
-			'name'          => __( 'Footer Widget Area Two', 'yikes_starter' ),
+			'name'          => __( 'Footer Widget Area Two', 'lwtv-underscores' ),
 			'id'            => 'footer-2',
 			'description'   => 'The second footer widget area.',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -255,7 +269,7 @@ function yikes_starter_widgets_init() {
 	// Footer Widget 3.
 	register_sidebar(
 		array(
-			'name'          => __( 'Footer Widget Area Three', 'yikes_starter' ),
+			'name'          => __( 'Footer Widget Area Three', 'lwtv-underscores' ),
 			'id'            => 'footer-3',
 			'description'   => 'The third footer widget area.',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -267,7 +281,7 @@ function yikes_starter_widgets_init() {
 	// Footer Widget 4.
 	register_sidebar(
 		array(
-			'name'          => __( 'Footer Widget Area Four', 'yikes_starter' ),
+			'name'          => __( 'Footer Widget Area Four', 'lwtv-underscores' ),
 			'id'            => 'footer-4',
 			'description'   => 'The third footer widget area.',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -279,7 +293,7 @@ function yikes_starter_widgets_init() {
 	// Credits Widget.
 	register_sidebar(
 		array(
-			'name'          => __( 'Bottom Footer Widget Area', 'yikes_starter' ),
+			'name'          => __( 'Bottom Footer Widget Area', 'lwtv-underscores' ),
 			'id'            => 'subfooter-1',
 			'description'   => 'The bottom footer credits area.',
 			'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -291,9 +305,9 @@ function yikes_starter_widgets_init() {
 	// Sidebar for Actor Archives.
 	register_sidebar(
 		array(
-			'name'          => esc_html__( 'Sidebar - Actor Archives', 'lwtv_yikes' ),
+			'name'          => esc_html__( 'Sidebar - Actor Archives', 'lwtv-underscores' ),
 			'id'            => 'archive-actor-sidebar',
-			'description'   => esc_html__( 'This is the sidebar for actor archives.', 'lwtv_yikes' ),
+			'description'   => esc_html__( 'This is the sidebar for actor archives.', 'lwtv-underscores' ),
 			'before_widget' => '<section id="%1$s" class="widget %2$s">',
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title">',
@@ -303,9 +317,9 @@ function yikes_starter_widgets_init() {
 	// Sidebar for Character Archives.
 	register_sidebar(
 		array(
-			'name'          => esc_html__( 'Sidebar - Character Archives', 'lwtv_yikes' ),
+			'name'          => esc_html__( 'Sidebar - Character Archives', 'lwtv-underscores' ),
 			'id'            => 'archive-character-sidebar',
-			'description'   => esc_html__( 'This is the sidebar for character archives.', 'lwtv_yikes' ),
+			'description'   => esc_html__( 'This is the sidebar for character archives.', 'lwtv-underscores' ),
 			'before_widget' => '<section id="%1$s" class="widget %2$s">',
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title">',
@@ -315,9 +329,9 @@ function yikes_starter_widgets_init() {
 	// Sidebar for Show Archives.
 	register_sidebar(
 		array(
-			'name'          => esc_html__( 'Sidebar - Show Archives', 'lwtv_yikes' ),
+			'name'          => esc_html__( 'Sidebar - Show Archives', 'lwtv-underscores' ),
 			'id'            => 'archive-show-sidebar',
-			'description'   => esc_html__( 'This is the sidebar for show archives.', 'lwtv_yikes' ),
+			'description'   => esc_html__( 'This is the sidebar for show archives.', 'lwtv-underscores' ),
 			'before_widget' => '<section id="%1$s" class="widget %2$s">',
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title">',

--- a/inc/lesbians.php
+++ b/inc/lesbians.php
@@ -352,7 +352,7 @@ function lwtv_symbolicons( $svg, $fa ) {
 	if ( empty( $symbolicon ) ) {
 		$symbolicon = '<span class="symbolicon" role="img"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="spinner" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-spinner fa-w-16 fa-3x"><path fill="currentColor" d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z" class=""></path></svg></span>';
 	}
-	return $return;
+	return $symbolicon;
 }
 
 /**

--- a/inc/lesbians.php
+++ b/inc/lesbians.php
@@ -299,9 +299,8 @@ function lwtv_yikes_actordata( $the_id, $data ) {
  * @param string $the_id
  * @return bool
  */
-function lwtv_yikes_is_queer( $the_id ) {
-	$is_queer = ( 'yes' === lwtv_plugin()->is_actor_queer( $the_id ) ) ? true : false;
-	return $is_queer;
+function lwtv_yikes_is_queer( $the_id ): bool {
+	return lwtv_plugin()->is_actor_queer( $the_id );
 }
 
 /**
@@ -311,9 +310,8 @@ function lwtv_yikes_is_queer( $the_id ) {
  * @param string $the_id
  * @return bool
  */
-function lwtv_yikes_is_birthday( $the_id ) {
-	$happy_birthday = lwtv_plugin()->is_actor_birthday( $the_id );
-	return $happy_birthday;
+function lwtv_yikes_is_birthday( $the_id ): bool {
+	return lwtv_plugin()->is_actor_birthday( $the_id );
 }
 
 /** THE SEO SECTION **/

--- a/inc/lesbians.php
+++ b/inc/lesbians.php
@@ -198,11 +198,9 @@ add_action( 'pre_get_posts', 'lwtv_yikes_character_archive_query' );
  * @return string $title_adjustment -- Adjusted title.
  */
 function lwtv_yikes_tax_archive_title( $location, $post_type, $taxonomy ) {
-	if ( class_exists( 'LWTV_Theme_Taxonomy_Archive_Title' ) ) {
-		$title_adjustment = ( new LWTV_Theme_Taxonomy_Archive_Title() )->make( $location, $post_type, $taxonomy );
-	}
+	$title_adjustment = lwtv_plugin()->get_tax_archive_title( $location, $post_type, $taxonomy );
 
-	if ( isset( $title_adjustment ) && ! empty( $title_adjustment ) ) {
+	if ( ! empty( $title_adjustment ) ) {
 		return $title_adjustment;
 	}
 }
@@ -237,11 +235,9 @@ if ( is_search() ) {
  * @return void
  */
 function lwtv_yikes_show_star( $show_id ) {
-	if ( class_exists( 'LWTV_Theme_Show_Stars' ) ) {
-		$star = ( new LWTV_Theme_Show_Stars() )->make( $show_id );
-	}
+	$star = lwtv_plugin()->get_show_stars( $show_id );
 
-	if ( isset( $star ) && ! empty( $star ) ) {
+	if ( ! empty( $star ) ) {
 		return $star;
 	}
 }
@@ -255,11 +251,9 @@ function lwtv_yikes_show_star( $show_id ) {
  * @return void
  */
 function lwtv_yikes_content_warning( $show_id ) {
-	if ( isset( $show_id ) && class_exists( 'LWTV_Theme_Content_Warning' ) ) {
-		$warning_array = ( new LWTV_Theme_Content_Warning() )->make( $show_id );
-	}
+	$warning_array = lwtv_plugin()->get_show_content_warning( $show_id );
 
-	if ( isset( $warning_array ) && is_array( $warning_array ) ) {
+	if ( is_array( $warning_array ) && ! empty( $warning_array ) ) {
 		return $warning_array;
 	}
 }
@@ -275,14 +269,7 @@ function lwtv_yikes_content_warning( $show_id ) {
  * @return void
  */
 function lwtv_yikes_chardata( $the_id, $data ) {
-
-	if ( isset( $the_id ) && class_exists( 'LWTV_Theme_Data_Character' ) ) {
-		$character_data = ( new LWTV_Theme_Data_Character() )->make( $the_id, $data );
-	}
-
-	if ( isset( $character_data ) ) {
-		return $character_data;
-	}
+	return lwtv_plugin()->get_character_data( $the_id, $data );
 }
 
 /**
@@ -293,16 +280,16 @@ function lwtv_yikes_chardata( $the_id, $data ) {
  * @access public
  * @param mixed $the_id: the actor post ID
  * @param mixed $data:
- * @return void
+ * @return mixed
  */
 function lwtv_yikes_actordata( $the_id, $data ) {
-	if ( isset( $the_id ) && class_exists( 'LWTV_Theme_Data_Actor' ) ) {
-		$actor_data = ( new LWTV_Theme_Data_Actor() )->make( $the_id, $data );
+	$actor_data = array();
+
+	if ( isset( $the_id ) ) {
+		$actor_data = lwtv_plugin()->get_actor_data( $the_id, $data );
 	}
 
-	if ( isset( $actor_data ) ) {
-		return $actor_data;
-	}
+	return $actor_data;
 }
 
 /**
@@ -313,11 +300,7 @@ function lwtv_yikes_actordata( $the_id, $data ) {
  * @return bool
  */
 function lwtv_yikes_is_queer( $the_id ) {
-	$is_queer = false;
-	if ( method_exists( 'LWTV_Queery_Is_Actor_Queer', 'make' ) ) {
-		$is_queer = ( 'yes' === ( new LWTV_Queery_Is_Actor_Queer() )->make( $the_id ) ) ? true : false;
-	}
-
+	$is_queer = ( 'yes' === lwtv_plugin()->is_actor_queer( $the_id ) ) ? true : false;
 	return $is_queer;
 }
 
@@ -329,10 +312,7 @@ function lwtv_yikes_is_queer( $the_id ) {
  * @return bool
  */
 function lwtv_yikes_is_birthday( $the_id ) {
-	$happy_birthday = false;
-	if ( class_exists( 'LWTV_Theme_Actor_Birthday' ) ) {
-		$happy_birthday = ( new LWTV_Theme_Actor_Birthday() )->make( $the_id );
-	}
+	$happy_birthday = lwtv_plugin()->is_actor_birthday( $the_id );
 	return $happy_birthday;
 }
 
@@ -367,10 +347,10 @@ function lwtv_microformats_fix( $post_id ) {
  * @return string      Whatever we end up with
  */
 function lwtv_symbolicons( $svg, $fa ) {
-	if ( method_exists( 'LWTV_Features', 'symbolicons' ) ) {
-		$return = ( new LWTV_Features() )->symbolicons( $svg, $fa );
-	} else {
-		$return = '<span class="symbolicon" role="img"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="spinner" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-spinner fa-w-16 fa-3x"><path fill="currentColor" d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z" class=""></path></svg></span>';
+	$symbolicon = lwtv_plugin()->get_symbolicon( $svg, $fa );
+
+	if ( empty( $symbolicon ) ) {
+		$symbolicon = '<span class="symbolicon" role="img"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="spinner" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-inline--fa fa-spinner fa-w-16 fa-3x"><path fill="currentColor" d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z" class=""></path></svg></span>';
 	}
 	return $return;
 }
@@ -382,9 +362,7 @@ function lwtv_symbolicons( $svg, $fa ) {
  * @return mixed   number or array listing the characters
  */
 function lwtv_list_characters( $post_id, $output ) {
-	if ( class_exists( 'LWTV_Theme_List_Characters' ) ) {
-		return ( new LWTV_Theme_List_Characters() )->make( $post_id, $output );
-	}
+	return lwtv_plugin()->get_list_characters( $post_id, $output );
 }
 
 /**
@@ -395,11 +373,7 @@ function lwtv_list_characters( $post_id, $output ) {
  * @return array           List of all the characters
  */
 function lwtv_get_chars_for_show( $post_id, $count, $roll ) {
-	$return = '';
-	if ( method_exists( 'LWTV_CPT_Characters', 'get_chars_for_show' ) ) {
-		$return = ( new LWTV_CPT_Characters() )->get_chars_for_show( $post_id, $count, $roll );
-	}
-	return $return;
+	return lwtv_plugin()->get_chars_for_show( $post_id, $count, $roll );
 }
 
 /**
@@ -422,14 +396,12 @@ function lwtv_last_updated_date( $post_id ) {
  * @return n/a
  */
 function lwtv_last_death() {
-	$return = '<p>The LezWatch.TV API is temporarily unavailable.</p>';
-	if ( class_exists( 'LWTV_Rest_API_BYQ' ) ) {
-		$last_death = ( new LWTV_Rest_API_BYQ() )->last_death();
-		if ( '' !== $last_death ) {
-			$return  = '<p>' . sprintf( 'It has been %s since the last queer female, non-binary, or transgender death on television', '<strong>' . human_time_diff( $last_death['died'], (int) wp_date( 'U' ) ) . '</strong> ' );
-			$return .= ': <span><a href="' . $last_death['url'] . '">' . $last_death['name'] . '</a></span> - ' . gmdate( 'F j, Y', $last_death['died'] ) . '</p>';
-			// NOTE! Add `class="hidden-death"` to the span above if you want to blur the display of the last death.
-		}
+	$return     = '<p>The LezWatch.TV API is temporarily unavailable.</p>';
+	$last_death = lwtv_plugin()->get_json_last_death();
+	if ( '' !== $last_death ) {
+		$return  = '<p>' . sprintf( 'It has been %s since the last queer female, non-binary, or transgender death on television', '<strong>' . human_time_diff( $last_death['died'], (int) wp_date( 'U' ) ) . '</strong> ' );
+		$return .= ': <span><a href="' . $last_death['url'] . '">' . $last_death['name'] . '</a></span> - ' . gmdate( 'F j, Y', $last_death['died'] ) . '</p>';
+		// NOTE! Add `class="hidden-death"` to the span above if you want to blur the display of the last death.
 	}
 
 	$return = '<div class="lezwatchtv last-death">' . $return . '</div>';
@@ -444,11 +416,7 @@ function lwtv_last_death() {
  * @return string $details Output of author social.
  */
 function lwtv_author_social( $author ) {
-	$return = '';
-	if ( class_exists( 'LWTV_Theme_Data_Author' ) ) {
-		$return = ( new LWTV_Theme_Data_Author() )->make( $author, 'social' );
-	}
-	return $return;
+	return lwtv_plugin()->get_author_social( $author );
 }
 
 /**
@@ -458,9 +426,5 @@ function lwtv_author_social( $author ) {
  * @return string $details Output of author fav shows.
  */
 function lwtv_author_favourite_shows( $author ) {
-	$return = '';
-	if ( class_exists( 'LWTV_Theme_Data_Author' ) ) {
-		$return = ( new LWTV_Theme_Data_Author() )->make( $author, 'favorite_shows' );
-	}
-	return $return;
+	return lwtv_plugin()->get_author_favorite_shows( $author );
 }

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -90,31 +90,31 @@ if ( ! function_exists( 'yikes_starter_entry_footer' ) ) :
 		// Hide category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
 			/* translators: used between list items, there is a space after the comma */
-			$categories_list = get_the_category_list( esc_html__( ', ', 'yikes_starter' ) );
+			$categories_list = get_the_category_list( esc_html__( ', ', 'lwtv-underscores' ) );
 			if ( $categories_list && yikes_starter_categorized_blog() ) {
 				// translators: 1 category list
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'yikes_starter' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput
+				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'lwtv-underscores' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 
 			/* translators: used between list items, there is a space after the comma */
-			$tags_list = get_the_tag_list( '', esc_html__( ', ', 'yikes_starter' ) );
+			$tags_list = get_the_tag_list( '', esc_html__( ', ', 'lwtv-underscores' ) );
 			if ( $tags_list ) {
 				// translators: 1 tags list
-				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'yikes_starter' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput
+				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'lwtv-underscores' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 		}
 
 		if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
 			echo '<span class="comments-link">';
 			/* translators: %s: post title */
-			comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'yikes_starter' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
+			comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'lwtv-underscores' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
 			echo '</span>';
 		}
 
 		edit_post_link(
 			sprintf(
 				/* translators: %s: Name of current post */
-				esc_html__( 'Edit %s', 'yikes_starter' ),
+				esc_html__( 'Edit %s', 'lwtv-underscores' ),
 				the_title( '<span class="screen-reader-text">"', '"</span>', false )
 			),
 			'<span class="edit-link">',

--- a/inc/widgets/character-widget.php
+++ b/inc/widgets/character-widget.php
@@ -13,7 +13,7 @@ class LWTV_Character extends WP_Widget {
 		parent::__construct(
 			'lwtv_character', // Base ID
 			'LWTV Recent Character', // Name
-			array( 'description' => __( 'Displays the character most recently added to the database.', 'yikes_starter' ) ) // Args
+			array( 'description' => __( 'Displays the character most recently added to the database.', 'lwtv-underscores' ) ) // Args
 		);
 	}
 

--- a/inc/widgets/filter-widget1.php
+++ b/inc/widgets/filter-widget1.php
@@ -13,7 +13,7 @@ class Filter_Top extends WP_Widget {
 		parent::__construct(
 			'filter_top', // Base ID
 			'LWTV Filter Container Top', // Name
-			array( 'description' => __( 'Used to wrap Show/Character filters.', 'yikes_starter' ) ) // Args
+			array( 'description' => __( 'Used to wrap Show/Character filters.', 'lwtv-underscores' ) ) // Args
 		);
 	}
 

--- a/inc/widgets/filter-widget2.php
+++ b/inc/widgets/filter-widget2.php
@@ -13,7 +13,7 @@ class Filter_Bottom extends WP_Widget {
 		parent::__construct(
 			'filter_bottom', // Base ID
 			'LWTV Filter Container Bottom', // Name
-			array( 'description' => __( 'Used to wrap Show/Character filters.', 'yikes_starter' ) ) // Args
+			array( 'description' => __( 'Used to wrap Show/Character filters.', 'lwtv-underscores' ) ) // Args
 		);
 	}
 

--- a/inc/widgets/my-widget.php
+++ b/inc/widgets/my-widget.php
@@ -13,7 +13,7 @@ class My_Widget extends WP_Widget {
 		parent::__construct(
 			'my_widget', // Base ID
 			'My Awesome Widget', // Name
-			array( 'description' => __( 'My Awesome widget I made myself', 'yikes_starter' ) ) // Args
+			array( 'description' => __( 'My Awesome widget I made myself', 'lwtv-underscores' ) ) // Args
 		);
 	}
 

--- a/inc/widgets/show-widget.php
+++ b/inc/widgets/show-widget.php
@@ -13,7 +13,7 @@ class LWTV_Show extends WP_Widget {
 		parent::__construct(
 			'lwtv_show', // Base ID
 			'LWTV Recent Show', // Name
-			array( 'description' => __( 'Displays the show most recently added to the database.', 'yikes_starter' ) ) // Args
+			array( 'description' => __( 'Displays the show most recently added to the database.', 'lwtv-underscores' ) ) // Args
 		);
 	}
 

--- a/inc/widgets/social-nav-widget.php
+++ b/inc/widgets/social-nav-widget.php
@@ -13,7 +13,7 @@ class YIKES_Social_Menu_Widget extends WP_Widget {
 		parent::__construct(
 			'yikes_social_menu_widget', // Base ID.
 			'YIKES Social Menu',        // Name.
-			array( 'description' => __( 'Display YIKES social menu', 'yikes_starter' ) ) // Args.
+			array( 'description' => __( 'Display YIKES social menu', 'lwtv-underscores' ) ) // Args.
 		);
 	}
 

--- a/page-templates/statistics.php
+++ b/page-templates/statistics.php
@@ -14,14 +14,7 @@ $validstat = array( 'death', 'characters', 'shows', 'main', 'actors', 'nations',
 $statstype = ( isset( $wp_query->query['statistics'] ) && in_array( $wp_query->query['statistics'], $validstat, true ) ) ? esc_attr( $wp_query->query['statistics'] ) : 'main';
 
 // Defaults:
-$theme_defaults = array(
-	'image' => lwtv_symbolicons( 'graph-bar.svg', 'fa-chart-area' ),
-	'intro' => '',
-);
-
-if ( class_exists( 'LWTV_Theme_Stats_Symbolicon' ) ) {
-	$theme_defaults = ( new LWTV_Theme_Stats_Symbolicon() )->make( $statstype );
-}
+$theme_defaults = lwtv_plugin()->get_stats_symbolicon( $statstype );
 
 $image = '<span role="img" aria-label="statistics" title="Statistics" class="taxonomy-svg statistics">' . $theme_defaults['image'] . '</span>';
 
@@ -73,13 +66,14 @@ get_header(); ?>
 								the_content();
 							}
 
-							if ( method_exists( 'LWTV_Statistics_Gutenberg_SSR', 'statistics' ) ) {
-								$attributes = array(
-									'page' => $statstype,
-								);
+							$attributes = array(
+								'page' => $statstype,
+							);
+							$stats      = lwtv_plugin()->generate_stats_block( $attributes );
 
+							if ( ! empty( $stats ) ) {
 								// phpcs:ignore WordPress.Security.EscapeOutput
-								echo ( new LWTV_Statistics_Gutenberg_SSR() )->statistics( $attributes );
+								echo $stats;
 							} else {
 								echo '<p>After this maintenance, statistics will be right back!</p>';
 							}

--- a/page-templates/thisyear.php
+++ b/page-templates/thisyear.php
@@ -54,10 +54,8 @@ get_header();
 					<div id="content" class="site-content clearfix" role="main">
 						<div class="thisyear">
 							<?php
-							if ( method_exists( 'LWTV_This_Year_Display', 'make' ) ) {
-								// phpcs:ignore WordPress.Security.EscapeOutput
-								echo ( new LWTV_This_Year_Display() )->make( $thisyear );
-							}
+							// phpcs:ignore WordPress.Security.EscapeOutput
+							echo lwtv_plugin()->get_this_year_display( $thisyear );
 							?>
 						</div>
 					</div><!-- #content -->

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Pushes to branches are automatically deployed via Github Actions as follows:
 ## Features
 
 * Supports three Custom Post Types and related taxonomies: Characters, Themes, Actors
-* Integrated with LWTV Plugin
+* Integrated with LWTV Plugin ( `lwtv_plugin()->FUNCTION()` )
 * Integrated with [FacetWP](https://facetwp.com), [Jetpack Instant Search](https://jetpack.com/support/search/), and [CMB2](https://cmb2.io/).
 * Additional custom image sizes: Show (960x400), Character (225x300), Actor (225x300)
 * Additional custom sidebars: Show, Character, and Actor Archives

--- a/rss-otd.php
+++ b/rss-otd.php
@@ -21,24 +21,24 @@ echo '<?xml version="1.0" encoding="' . esc_attr( get_option( 'blog_charset' ) )
 	<title>LezWatch.TV Of The Day - Feed</title>
 	<atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
 	<link><?php echo esc_url( bloginfo_rss( 'url' ) ); ?></link>
-	<description>Keep up to date with the latest featured characters and shows! Updated daily.</description>
+	<description>Keep up to date with the latest featured characters and shows! Updated twice a day.</description>
 	<lastBuildDate>
-		<?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', ( new LWTV_Of_The_Day_RSS() )->last_build(), false ) ); ?>
+		<?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', lwtv_plugin()->get_rss_otd_last_build(), false ) ); ?>
 	</lastBuildDate>
 	<language>en-US</language>
 	<sy:updatePeriod><?php echo esc_html( apply_filters( 'rss_update_period', 'hourly' ) ); ?></sy:updatePeriod>
 	<sy:updateFrequency><?php echo esc_html( apply_filters( 'rss_update_frequency', '1' ) ); ?></sy:updateFrequency>
-	<generator>https://wordpress.org/?v=<?php echo floatval( ( new LWTV_Of_The_Day_RSS() )->return_wp_version() ); ?></generator>
+	<generator>https://wordpress.org/?v=<?php echo floatval( lwtv_plugin()->get_wp_version() ); ?></generator>
 	<image>
 		<url><?php echo esc_url( get_option( 'jetpack_site_icon_url' ) ); ?></url>
 		<title>LezWatch.TV Of The Day - Feed</title>
 		<link><?php echo esc_url( get_site_url() ); ?>/feed/otd/</link>
 		<width>32</width>
 		<height>32</height>
-	</image> 
+	</image>
 	<?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	( new LWTV_Of_The_Day_RSS() )->rss_feed();
+	lwtv_plugin()->get_rss_otd_feed();
 	?>
 </channel>
 </rss>

--- a/search.php
+++ b/search.php
@@ -15,7 +15,7 @@ get_header(); ?>
 					<div class="col-10"><h1 class="entry-title">
 					<?php
 						// translators: %s is whatever you just searched for.
-						printf( esc_attr__( 'Search Results for: %s', 'yikes_starter' ), '<span>' . get_search_query() . '</span>' );
+						printf( esc_attr__( 'Search Results for: %s', 'lwtv-underscores' ), '<span>' . get_search_query() . '</span>' );
 					?>
 					</h1></div>
 					<div class="col-2 icon plain">

--- a/searchform.php
+++ b/searchform.php
@@ -13,7 +13,7 @@
 	<div class="card-body">
 		<form role="search" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get">
 			<div class="input-group input-group-sm">
-				<input type="text" name="s" id="search" class="form-control" aria-label="Search for..." value="<?php the_search_query(); ?>" title="<?php echo esc_html_x( 'Search for:', 'label', 'yikes_starter' ); ?>" >
+				<input type="text" name="s" id="search" class="form-control" aria-label="Search for..." value="<?php the_search_query(); ?>" title="<?php echo esc_html_x( 'Search for:', 'label', 'lwtv-underscores' ); ?>" >
 				<?php
 				if ( ! class_exists( 'Jetpack_Search' ) ) {
 					?>

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -8,7 +8,7 @@
 
 <article class="post no-results not-found">
 	<header class="entry-header">
-		<h1 class="entry-title"><?php esc_attr_e( 'Nothing Found', 'yikes_starter' ); ?></h1>
+		<h1 class="entry-title"><?php esc_attr_e( 'Nothing Found', 'lwtv-underscores' ); ?></h1>
 	</header><!-- .entry-header -->
 
 	<div class="entry-content">
@@ -17,18 +17,18 @@
 		<p>
 			<?php
 			// translators: $1 is a link to wp-admin
-			printf( esc_attr__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'yikes_starter' ), esc_url( admin_url( 'post-new.php' ) ) );
+			printf( esc_attr__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'lwtv-underscores' ), esc_url( admin_url( 'post-new.php' ) ) );
 			?>
 		</p>
 
 		<?php elseif ( is_search() ) : ?>
 
-			<p><?php esc_attr_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'yikes_starter' ); ?></p>
+			<p><?php esc_attr_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'lwtv-underscores' ); ?></p>
 			<?php get_search_form(); ?>
 
 		<?php else : ?>
 
-			<p><?php esc_attr_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'yikes_starter' ); ?></p>
+			<p><?php esc_attr_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'lwtv-underscores' ); ?></p>
 			<?php get_search_form(); ?>
 
 		<?php endif; ?>

--- a/template-parts/content-post_type_actors.php
+++ b/template-parts/content-post_type_actors.php
@@ -14,12 +14,10 @@ $get_tags = get_term_by( 'name', $slug, 'post_tag' );
 
 // This just gets the numbers of all characters and how many are dead.
 $all_chars     = lwtv_yikes_actordata( $the_id, 'characters' );
-$havecharcount = count( $all_chars );
+$havecharcount = ( is_array( $all_chars ) ) ? count( $all_chars ) : 0;
 $havedeadcount = count( lwtv_yikes_actordata( $the_id, 'dead' ) );
 
-if ( method_exists( 'LWTV_CPTs_Related_Posts', 'are_there_posts' ) ) {
-	$related = ( new LWTV_CPTs_Related_Posts() )->are_there_posts( $slug );
-}
+$related = lwtv_plugin()->has_cpt_related_posts( $slug );
 
 // Generate Life Stats.
 // Usage: $life.
@@ -32,7 +30,7 @@ if ( isset( $barr ) && isset( $barr[1] ) && isset( $barr[2] ) && checkdate( (int
 	$get_birth    = new DateTime( $born );
 	$age          = lwtv_yikes_actordata( $the_id, 'age', true );
 	$life['born'] = date_format( $get_birth, 'F j, Y' );
-	$life['age']  = $age->format( '%Y years old' );
+	$life['age']  = ( is_object( $age ) ) ? $age->format( '%Y years old' ) : '';
 }
 $died = get_post_meta( $the_id, 'lezactors_death', true );
 if ( ! empty( $died ) ) {
@@ -253,7 +251,7 @@ if ( isset( $related ) && $related ) {
 		<div class="card-body">
 			<?php
 			if ( method_exists( 'LWTV_CPTs_Related_Posts', 'related_posts' ) && method_exists( 'LWTV_CPTs_Related_Posts', 'count_related_posts' ) ) {
-				echo ( new LWTV_CPTs_Related_Posts() )->related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
+				echo lwtv_plugin()->get_cpt_related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 			?>
 		</div>
@@ -299,13 +297,14 @@ if ( 0 !== $havecharcount ) {
 			<div class="card-meta">
 				<div class="card-meta-item">
 					<?php
-					if ( method_exists( 'LWTV_Statistics_Gutenberg_SSR', 'statistics' ) ) {
-						$attributes = array(
-							'posttype' => get_post_type(),
-						);
+					$attributes = array(
+						'posttype' => get_post_type(),
+					);
+					$stats      = lwtv_plugin()->generate_stats_block_actor( $attributes );
 
+					if ( ! empty( $stats ) ) {
 						// phpcs:ignore WordPress.Security.EscapeOutput
-						echo ( new LWTV_Statistics_Gutenberg_SSR() )->mini_stats( $attributes );
+						echo $stats;
 					} else {
 						echo '<p>After this maintenance, statistics will be right back!</p>';
 					}

--- a/template-parts/content-post_type_actors.php
+++ b/template-parts/content-post_type_actors.php
@@ -60,7 +60,7 @@ if ( $pronoun_terms && ! is_wp_error( $pronoun_terms ) ) {
 	$count    = 1;
 	foreach ( $pronoun_terms as $pronoun_term ) {
 		$pronouns .= $pronoun_term->name;
-		$pronouns .= ( $count < count( $pronoun_terms ) ) ? ' &bull; ' : '';
+		$pronouns .= ( $count < count( $pronoun_terms ) ) ? '/' : '';
 		++$count;
 	}
 	if ( isset( $pronouns ) && ! empty( $pronouns ) ) {

--- a/template-parts/content-post_type_shows.php
+++ b/template-parts/content-post_type_shows.php
@@ -10,8 +10,8 @@
 $show_id        = $post->ID;
 $slug           = get_post_field( 'post_name', get_post( $show_id ) );
 $get_tags       = get_term_by( 'name', $slug, 'post_tag' );
-$related        = ( new LWTV_CPTs_Related_Posts() )->are_there_posts( $slug );
-$rpbt_shortcode = ( new LWTV_Shows_Like_This() )->make( $show_id );
+$related        = lwtv_plugin()->has_cpt_related_posts( $slug );
+$rpbt_shortcode = lwtv_plugin()->get_shows_like_this_show( $show_id );
 
 // Microformats Fix.
 lwtv_microformats_fix( $post->ID );
@@ -86,7 +86,7 @@ if ( is_array( $warning ) && 'none' !== $warning['card'] ) {
 <?php
 // Ways to Watch section (yes all ways-to-watch URLs are in a badly named post_meta).
 if ( ( get_post_meta( $show_id, 'lezshows_affiliate', true ) ) ) {
-	echo '<section id="affiliate-watch-link" class="affiliate-watch-container">' . ( new LWTV_Theme_Ways_To_Watch() )->ways_to_watch( $show_id ) . '</section>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo '<section id="affiliate-watch-link" class="affiliate-watch-container">' . lwtv_plugin()->get_ways_to_watch( $show_id ) . '</section>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 ?>
 
@@ -129,7 +129,7 @@ if ( $related ) {
 		<div class="container"><div class="card-body">
 			<?php
 			if ( method_exists( 'LWTV_CPTs_Related_Posts', 'related_posts' ) && method_exists( 'LWTV_CPTs_Related_Posts', 'count_related_posts' ) ) {
-				echo ( new LWTV_CPTs_Related_Posts() )->related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
+				echo lwtv_plugin()->get_cpt_related_posts( $slug ); // phpcs:ignore WordPress.Security.EscapeOutput
 			}
 			?>
 		</div></div>
@@ -156,8 +156,8 @@ if ( $related ) {
 
 		// If havecharcount and chars_total are different, rerun the call.
 		if ( $chars_total !== $havecharcount ) {
-			$havecharcount = ( new LWTV_CPT_Characters() )->list_characters( $show_id, 'count' );
-			$havedeadcount = ( new LWTV_CPT_Characters() )->list_characters( $show_id, 'dead' );
+			$havecharcount = lwtv_plugin()->get_characters_list( $show_id, 'count' );
+			$havedeadcount = lwtv_plugin()->get_characters_list( $show_id, 'dead' );
 		}
 
 		if ( empty( $havecharcount ) || '0' === $havecharcount ) {

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -30,7 +30,7 @@
 		<?php
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_attr__( 'Pages:', 'yikes_starter' ),
+				'before' => '<div class="page-links">' . esc_attr__( 'Pages:', 'lwtv-underscores' ),
 				'after'  => '</div>',
 			)
 		);
@@ -39,23 +39,23 @@
 	<footer class="entry-meta">
 		<?php
 		/* translators: used between list items, there is a space after the comma */
-		$category_list = get_the_category_list( __( ', ', 'yikes_starter' ) );
+		$category_list = get_the_category_list( __( ', ', 'lwtv-underscores' ) );
 
 		/* translators: used between list items, there is a space after the comma */
-		$tag_list = get_the_tag_list( '', __( ', ', 'yikes_starter' ) );
+		$tag_list = get_the_tag_list( '', __( ', ', 'lwtv-underscores' ) );
 
 		if ( ! yikes_starter_categorized_blog() ) {
 			// This blog only has 1 category so we just need to worry about tags in the meta text
 			if ( '' !== $tag_list ) {
-				$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'tag.svg', 'fa-tags' ) . '&nbsp;%2$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'yikes_starter' );
+				$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'tag.svg', 'fa-tags' ) . '&nbsp;%2$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'lwtv-underscores' );
 			} else {
-				$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'yikes_starter' );
+				$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'lwtv-underscores' );
 			}
 		} elseif ( '' !== $tag_list ) {
 			// But this blog has loads of categories so we should probably display them here
-			$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'folder-open.svg', 'fa-folder-open' ) . '&nbsp;%1$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'tag.svg', 'fa-tags' ) . '&nbsp;%2$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'yikes_starter' );
+			$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'folder-open.svg', 'fa-folder-open' ) . '&nbsp;%1$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'tag.svg', 'fa-tags' ) . '&nbsp;%2$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'lwtv-underscores' );
 		} else {
-			$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'folder-open.svg', 'fa-folder-open' ) . '&nbsp;%1$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'yikes_starter' );
+			$meta_text = __( '<span class="footer-entry-meta-item">' . lwtv_symbolicons( 'folder-open.svg', 'fa-folder-open' ) . '&nbsp;%1$s</span> <span class="footer-entry-meta-item">' . lwtv_symbolicons( 'bookmark.svg', 'fa-bookmark' ) . '&nbsp;<a href="%3$s" title="Permalink to %4$s" rel="bookmark">Post link</a></span>', 'lwtv-underscores' );
 		} // End if.
 
 		printf(

--- a/template-parts/embed-content-post_type_shows.php
+++ b/template-parts/embed-content-post_type_shows.php
@@ -17,7 +17,7 @@
 		border: 1px solid #d1548e;
 		color: #222;
 		display: grid;
-		grid-template-areas: 
+		grid-template-areas:
 		"title title"
 		"image details"
 		"excerpt excerpt"
@@ -75,7 +75,7 @@
 		align-items: center;
 		grid-area: footer;
 		display: grid;
-		grid-template-areas: 
+		grid-template-areas:
 			"site flag";
 		grid-template-columns: 50% 50%;
 		margin:  0;
@@ -198,7 +198,7 @@
 				// Next Episode (if none, show 'aired on...')
 				$on_air = get_post_meta( get_the_ID(), 'lezshows_on_air', true );
 				if ( 'yes' === $on_air ) {
-					$tvmaze = ( new LWTV_Whats_On_JSON() )->whats_on_show( get_the_ID() );
+					$tvmaze = lwtv_plugin()->get_whats_on_show( get_the_ID() );
 					echo '<strong>Next Episode:</strong> ';
 					if ( isset( $tvmaze['next'] ) ) {
 						echo wp_kses_post( $tvmaze['next'] );
@@ -222,7 +222,7 @@
 
 		<div class="wp-embed-footer">
 			<div class="wp-embed-site">
-				<?php the_embed_site_title(); ?>				
+				<?php the_embed_site_title(); ?>
 			</div>
 
 			<div class="wp-embed-flag">

--- a/template-parts/searchbox.php
+++ b/template-parts/searchbox.php
@@ -10,7 +10,7 @@
 	<div class="form-group row">
 		<label class="col-sm-3 col-form-label" for="search">Search the Site</label>
 		<div class="col-sm-7 searchbox-input">
-			<input type="text" name="s" id="search" class="form-control" placeholder="<?php echo esc_attr_x( 'Enter keywords &hellip;', 'placeholder', 'yikes_starter' ); ?>" value="<?php the_search_query(); ?>" title="<?php echo esc_attr_x( 'Search for:', 'label', 'yikes_starter' ); ?>" />
+			<input type="text" name="s" id="search" class="form-control" placeholder="<?php echo esc_attr_x( 'Enter keywords &hellip;', 'placeholder', 'lwtv-underscores' ); ?>" value="<?php the_search_query(); ?>" title="<?php echo esc_attr_x( 'Search for:', 'label', 'lwtv-underscores' ); ?>" />
 		</div>
 		<?php
 		if ( ! class_exists( 'Jetpack_Search' ) ) {

--- a/template-parts/sidebar-post_type_shows.php
+++ b/template-parts/sidebar-post_type_shows.php
@@ -65,10 +65,10 @@ $alt_names    = ( get_post_meta( $show_id, 'lezshows_show_names', true ) ) ? get
 				}
 
 				// Collect all the scores.
-				$scores = ( new LWTV_Grading() )->all_scores( $show_id );
+				$scores = lwtv_plugin()->get_all_scores( $show_id );
 				if ( isset( $scores ) ) {
 					echo '<center><h4>Show Scores</h4></center>';
-					( new LWTV_Grading() )->display( $scores );
+					lwtv_plugin()->display_scores( $scores );
 				}
 				?>
 			</div>
@@ -87,7 +87,7 @@ $alt_names    = ( get_post_meta( $show_id, 'lezshows_show_names', true ) ) ? get
 				// If the show is on air, we'll see when it airs next!
 				$on_air = get_post_meta( $show_id, 'lezshows_on_air', true );
 				if ( 'yes' === $on_air ) {
-					( new LWTV_Theme_TVMaze() )->episodes( $show_id );
+					lwtv_plugin()->get_tvmaze_episodes( $show_id );
 				}
 
 				$formats = get_the_terms( $show_id, 'lez_formats' );


### PR DESCRIPTION
Required as soon as namespace conversion in plugin is done (see https://github.com/LezWatch/lwtv-plugin/pull/393 )

There are no real changes to the theme, just to the wrappers.

Where we used to do this:

`( new LWTV_CPTs_Related_Posts() )->related_archive_header( $tag_id );`

We can now do this:

`lwtv_plugin()->get_related_archive_header( $tag_id );`

Now you don't have to know what class/namespace is what!

Also made better use of checks to ensure functions are available when called (thank you Intellephense!) and we don't allow malformed data to attempt to run.