### PR TITLE
Fix Runner Actions

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup PHP and Composer
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           tools: composer:v2
 
       - name: Install dependencies

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup PHP and Composer
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           tools: composer:v2
 
       - name: Install dependencies


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10636

If https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/ breaks the deployment, we'll want to use this. Otherwise we may not need it.