### PR TITLE
Updates - 2025 Feb

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1256,16 +1256,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.3",
+            "version": "11.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "30e319e578a7b5da3543073e30002bf82042f701"
+                "reference": "3c3ae14c90f244cdda95028c3e469028e8d1c02c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/30e319e578a7b5da3543073e30002bf82042f701",
-                "reference": "30e319e578a7b5da3543073e30002bf82042f701",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3c3ae14c90f244cdda95028c3e469028e8d1c02c",
+                "reference": "3c3ae14c90f244cdda95028c3e469028e8d1c02c",
                 "shasum": ""
             },
             "require": {
@@ -1337,7 +1337,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.6"
             },
             "funding": [
                 {
@@ -1353,7 +1353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-13T09:36:00+00:00"
+            "time": "2025-01-31T07:03:30+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "dependencies": {
         "@npmcli/fs": "^4",
         "@popperjs/core": "^2.11.8",
-        "@wordpress/components": "^29.2.0",
+        "@wordpress/components": "^29.3.0",
         "chart.js": "^4",
         "chartjs-plugin-annotation": "^3",
         "coffeescript": "^2.7.0",
@@ -27,7 +27,7 @@
         "@lodder/grunt-postcss": "^3.1",
         "@parcel/watcher": "^2.5",
         "@types/node": "^22",
-        "@wordpress/scripts": "^30.9.0",
+        "@wordpress/scripts": "^30.10.0",
         "autoprefixer": "^10.4",
         "css-minimizer-webpack-plugin": "^7.0",
         "eslint-plugin-prettier": "^5.2",
@@ -3550,14 +3550,14 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
-      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright": "1.50.0"
+        "playwright": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4290,9 +4290,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.5.tgz",
-      "integrity": "sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4446,9 +4446,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5152,14 +5152,14 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.16.0.tgz",
-      "integrity": "sha512-i3zrNFx+N+dNivQxUeQXWKGT1ccWePXcqPkVTqjdO+lACv+MtJoyE9PXZCmaxHWq00g1RTvIpLtrzV5L4gzZkA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.17.0.tgz",
+      "integrity": "sha512-TCQ/PGC0Me3yzPUrmY2FpECl7GUcUcx6kVGUugmlMxNwxeZRYUOEMxsHGm07iKV5l7zbi3y5c/i5bbYwJfXA4g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/dom-ready": "^4.16.0",
-        "@wordpress/i18n": "^5.16.0"
+        "@wordpress/dom-ready": "^4.17.0",
+        "@wordpress/i18n": "^5.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5167,14 +5167,14 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.16.0.tgz",
-      "integrity": "sha512-JMHUUWQQnuFDYQfWtOBPxbB8YEefew3fnGwwDrdOAN7drkZ7ob7fJ2H1tY6iV5i+wIEl/5em3f0jXD3zcwkBDw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.17.0.tgz",
+      "integrity": "sha512-L3iT/K41R6KResTy/7EOsTD+KKO20U3B4lPz/jQMRNgFdq4MOxtalEMjrRoj1mG+qiYGYdvGmpSgOzSx9o3eRg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^5.16.0",
-        "@wordpress/url": "^4.16.0"
+        "@wordpress/i18n": "^5.17.0",
+        "@wordpress/url": "^4.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5182,9 +5182,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.16.0.tgz",
-      "integrity": "sha512-5/XBRZ7Y731moR/hzZ+/k9tavHMHvshi+IdsJAecgUcqYC45YMLmqOmA4DOzfzCjBkuVvoy+6itMHQ+Q87Gb9g==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.17.0.tgz",
+      "integrity": "sha512-6O9Eo/S02OHIa4GflfcWHANHpuy5/SifaWiprWYTrhIt6L6DyVxr1AErSWfDXIrkNNVXuhhykYDHAtApKqpqsQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5195,9 +5195,9 @@
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.16.0.tgz",
-      "integrity": "sha512-3vRdagepfoIduDX25dzUbsCyE8eZsQGkVIRTrE2Kpi7YBzAzZz8nHPX1arDhIfEZn6QYGt5tIW5yNC8bbALsWQ==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.17.0.tgz",
+      "integrity": "sha512-v2grJpRzSArNqASHgwYGSHfkSQKrZvQEjGFhiNgcZ10J/7L9NrKlzsguuQD/Yq6LeWwqvrKUUjSNe5hwSU6/jA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -5208,9 +5208,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.16.0.tgz",
-      "integrity": "sha512-CPAMxQ5eMmsRNJN0edUZvsJDnmALQFGbWyCxsJiJJ/0LFi1lYFC7r5YGcJXVVD+oX9L908NZpxwsQBHb6gkxig==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.17.0.tgz",
+      "integrity": "sha512-+ivwvBI92u6abFf0DlwHem8fH5HujKy5e8a0cwDBOJivEzIJLPKYSYLlnLZL9I0QIstB+KdcJBARuWuR0l58Sw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5220,8 +5220,8 @@
         "@babel/preset-env": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
         "@babel/runtime": "7.25.7",
-        "@wordpress/browserslist-config": "^6.16.0",
-        "@wordpress/warning": "^3.16.0",
+        "@wordpress/browserslist-config": "^6.17.0",
+        "@wordpress/warning": "^3.17.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.0"
@@ -5406,9 +5406,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.16.0.tgz",
-      "integrity": "sha512-CAaRCkoJ83+XeObkY1aiswInVHCm5JBFVCCtkEVvRlbqNipHCMyhA3rg501Ww4AOYxsX9r2rvNbGaAPMGc6oug==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.17.0.tgz",
+      "integrity": "sha512-9rYupV2CIS6PIlE27vxqBEn98n2hEBdI4YQI7TD7kdbGHYRDfTqocDK7stiAgqKR9ujDoVmq+Yk3T/jzRi6WoA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5417,9 +5417,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.16.0.tgz",
-      "integrity": "sha512-vhaEhh0jqSZG+LPrLL6wco4kmw4lYC6OLTOspeOWuAEPMKOs4YyfF8x2iA8p6CZiWjVcahwZlcP7DnZDIwowsQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.17.0.tgz",
+      "integrity": "sha512-qH0Q48clM+UTdTMWUsCyyAuy4J+koNGLz4oXyJZCrUvUQ31Hpj6VwQulM2lSXYQyzOWJEKf3deHM47Uz1JYhhg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5430,9 +5430,9 @@
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.16.0.tgz",
-      "integrity": "sha512-F8n8GMeVAepWl9nuA9Ly/WWaqvZ9Lg0KI/OUd0Bm0Y3Ssz65UNRf6DT+ScN35OCAOklf1bQ1PGaq9JdVmC43mg==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.17.0.tgz",
+      "integrity": "sha512-4oVgm6f/kRqersuTH1SS85x89P4foPAo2xwjoXvHdjy1Rp0UQ86uxyKn0j0A6k7uQEXc5BJeUevk/Z1AT1Z9bQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5443,27 +5443,27 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-14.5.0.tgz",
-      "integrity": "sha512-RsX8hWsTegbkUaYcqIfYE2k1OEkF3hOV3PZFsm9Zn1ZN0/ESUQGRXxUCQvr/7yZIjMRxVNnakYlln2OMrXt1rQ==",
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-14.6.0.tgz",
+      "integrity": "sha512-9FkjXHRTXIaOU7BJfoeRUe1snh+5H8rypOTJoDpiMCoXMfGKyBVpacRMzbltQiK7SrzmHbzst4EuxHoK7a/TVw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/autop": "^4.16.0",
-        "@wordpress/blob": "^4.16.0",
-        "@wordpress/block-serialization-default-parser": "^5.16.0",
-        "@wordpress/data": "^10.16.0",
-        "@wordpress/deprecated": "^4.16.0",
-        "@wordpress/dom": "^4.16.0",
-        "@wordpress/element": "^6.16.0",
-        "@wordpress/hooks": "^4.16.0",
-        "@wordpress/html-entities": "^4.16.0",
-        "@wordpress/i18n": "^5.16.0",
-        "@wordpress/is-shallow-equal": "^5.16.0",
-        "@wordpress/private-apis": "^1.16.0",
-        "@wordpress/rich-text": "^7.16.0",
-        "@wordpress/shortcode": "^4.16.0",
-        "@wordpress/warning": "^3.16.0",
+        "@wordpress/autop": "^4.17.0",
+        "@wordpress/blob": "^4.17.0",
+        "@wordpress/block-serialization-default-parser": "^5.17.0",
+        "@wordpress/data": "^10.17.0",
+        "@wordpress/deprecated": "^4.17.0",
+        "@wordpress/dom": "^4.17.0",
+        "@wordpress/element": "^6.17.0",
+        "@wordpress/hooks": "^4.17.0",
+        "@wordpress/html-entities": "^4.17.0",
+        "@wordpress/i18n": "^5.17.0",
+        "@wordpress/is-shallow-equal": "^5.17.0",
+        "@wordpress/private-apis": "^1.17.0",
+        "@wordpress/rich-text": "^7.17.0",
+        "@wordpress/shortcode": "^4.17.0",
+        "@wordpress/warning": "^3.17.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -5491,9 +5491,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.16.0.tgz",
-      "integrity": "sha512-ppjgUOjCFwLjH5XCDAfavRkIAj9DKEVGj12YMGL+dzSikbDU9L8VnMT1p08G1bAcBkTRLtBX8KkJJdyUI1JGsQ==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.17.0.tgz",
+      "integrity": "sha512-cjMclWLwfam5O03gOHWjD8veeLVnfmC93V9LX1aPt/ZT9aE0cmEZUxBa3VzkDM7NvuZFj7SjSvJr+vuar9Np1A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5502,9 +5502,9 @@
       }
     },
     "node_modules/@wordpress/components": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.2.0.tgz",
-      "integrity": "sha512-a7vUL4oUGu4Jicqf0cFSdQvGtZVw9h4Gvxr53o8yJYmXY8YRVrbeEsZjA/twaqRa8WxGzzWnWNQ/XwtMEXNG0w==",
+      "version": "29.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.3.0.tgz",
+      "integrity": "sha512-9lQIXsbgFeGY1QXEhNHQ6mq+6sS1TGGdZdaGSoQoP682WWgdjshnyq/0yhGULY9ReDKnZF2mHJ/J3FvleyYMcg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
@@ -5519,23 +5519,23 @@
         "@types/gradient-parser": "0.1.3",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.16.0",
-        "@wordpress/compose": "^7.16.0",
-        "@wordpress/date": "^5.16.0",
-        "@wordpress/deprecated": "^4.16.0",
-        "@wordpress/dom": "^4.16.0",
-        "@wordpress/element": "^6.16.0",
-        "@wordpress/escape-html": "^3.16.0",
-        "@wordpress/hooks": "^4.16.0",
-        "@wordpress/html-entities": "^4.16.0",
-        "@wordpress/i18n": "^5.16.0",
-        "@wordpress/icons": "^10.16.0",
-        "@wordpress/is-shallow-equal": "^5.16.0",
-        "@wordpress/keycodes": "^4.16.0",
-        "@wordpress/primitives": "^4.16.0",
-        "@wordpress/private-apis": "^1.16.0",
-        "@wordpress/rich-text": "^7.16.0",
-        "@wordpress/warning": "^3.16.0",
+        "@wordpress/a11y": "^4.17.0",
+        "@wordpress/compose": "^7.17.0",
+        "@wordpress/date": "^5.17.0",
+        "@wordpress/deprecated": "^4.17.0",
+        "@wordpress/dom": "^4.17.0",
+        "@wordpress/element": "^6.17.0",
+        "@wordpress/escape-html": "^3.17.0",
+        "@wordpress/hooks": "^4.17.0",
+        "@wordpress/html-entities": "^4.17.0",
+        "@wordpress/i18n": "^5.17.0",
+        "@wordpress/icons": "^10.17.0",
+        "@wordpress/is-shallow-equal": "^5.17.0",
+        "@wordpress/keycodes": "^4.17.0",
+        "@wordpress/primitives": "^4.17.0",
+        "@wordpress/private-apis": "^1.17.0",
+        "@wordpress/rich-text": "^7.17.0",
+        "@wordpress/warning": "^3.17.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -5563,20 +5563,20 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.16.0.tgz",
-      "integrity": "sha512-FTpfEUeEyH3LnVRlNZxRwce3sEUPDAVI1P+AaF7ZrbzcV2ita4WamCoEHFDS4OMOnvISnSbVh2Rz3gF9oLvomQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.17.0.tgz",
+      "integrity": "sha512-jn5uCw08HHLfOpIDp0pKBDZh1oZiMwjiK3c3IZdZo6eoWZjpOr3ecsMa4RBl/4HbqnUoeFDD6Lj83IEKPuzHQg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.16.0",
-        "@wordpress/dom": "^4.16.0",
-        "@wordpress/element": "^6.16.0",
-        "@wordpress/is-shallow-equal": "^5.16.0",
-        "@wordpress/keycodes": "^4.16.0",
-        "@wordpress/priority-queue": "^3.16.0",
-        "@wordpress/undo-manager": "^1.16.0",
+        "@wordpress/deprecated": "^4.17.0",
+        "@wordpress/dom": "^4.17.0",
+        "@wordpress/element": "^6.17.0",
+        "@wordpress/is-shallow-equal": "^5.17.0",
+        "@wordpress/keycodes": "^4.17.0",
+        "@wordpress/priority-queue": "^3.17.0",
+        "@wordpress/undo-manager": "^1.17.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -5591,19 +5591,19 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.16.0.tgz",
-      "integrity": "sha512-5Gx0Hb1VsnvACQJBJhgaFf0xn6cf1s0Wqv3q2DRnRShuSQTNxkUxA41+eZsPxC1JrnVXg0vPRCu5GpqwPO4O9g==",
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.17.0.tgz",
+      "integrity": "sha512-NezfpsRH3BIV2i10wFohsGfOQ+pp9TvSHFuVK/AlQmnAogoMpFOxAumXCI7rvDoH1X4rEPiX2ggRnxP2+Z6jwQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.16.0",
-        "@wordpress/deprecated": "^4.16.0",
-        "@wordpress/element": "^6.16.0",
-        "@wordpress/is-shallow-equal": "^5.16.0",
-        "@wordpress/priority-queue": "^3.16.0",
-        "@wordpress/private-apis": "^1.16.0",
-        "@wordpress/redux-routine": "^5.16.0",
+        "@wordpress/compose": "^7.17.0",
+        "@wordpress/deprecated": "^4.17.0",
+        "@wordpress/element": "^6.17.0",
+        "@wordpress/is-shallow-equal": "^5.17.0",
+        "@wordpress/priority-queue": "^3.17.0",
+        "@wordpress/private-apis": "^1.17.0",
+        "@wordpress/redux-routine": "^5.17.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -5621,13 +5621,13 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.16.0.tgz",
-      "integrity": "sha512-Sb2eJ7S7bn7ODfe0WVgNEqLpilgwpKIoJjVxMxT8wtJpx4rEs25+BAyQ6Bpj6lxX9P99ZmPsdrq5YavxP9NKHg==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.17.0.tgz",
+      "integrity": "sha512-vFi+h+YpiicfDHtp1SKkFmgQR0PI9I76Dqoi7lBP95BPTGC/adQ3u2ee5wGd5uVUlR+ca+TfR6siC4Igau73oA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.16.0",
+        "@wordpress/deprecated": "^4.17.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -5637,9 +5637,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.16.0.tgz",
-      "integrity": "sha512-AU6SFATdbUJsd/hqD6wUaZxbikibJ4L7RGpQ2MPUsXxXZCJU8pfPE3WWIOM1VemG4dJRJO+jk0lG8uH9pwdsfA==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.17.0.tgz",
+      "integrity": "sha512-aRiYH1lcgxnvo0dvhEd5dxjBiWQokRdzSHFSF5flZ4vmHVvDRSgj5V0CQTuCG4fr77PwEJNjPHOm+s1JbmmQJw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5661,13 +5661,13 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.16.0.tgz",
-      "integrity": "sha512-apv94cskjvWqkanqNn3vP7lugJODkSkPlLqjKPY5iBXI0RATaKuxcTNxuO9/Gn5QcuM89fjhsGTcZ4X/SZTGNQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.17.0.tgz",
+      "integrity": "sha512-7IlFpQ6tNkUbOuuxm6kBCR2R6C9Etlzojgh0ykJ/OmwgRMrosH/m6/zAmaA15oRYpd6dvO7ozJN+ArPz7LSOiQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.16.0"
+        "@wordpress/hooks": "^4.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5675,13 +5675,13 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.16.0.tgz",
-      "integrity": "sha512-iT9D8BnoSgD9w+viDCKtO7lfMmzku3tC7oLEakH6LNZRas0jQuTC46cfokMAz6HTchxiAnuXoPYHsCPhGzWy8Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.17.0.tgz",
+      "integrity": "sha512-raAeub1L/a2yHd9rwCGs67yDSUsafcpERi9rJCeHiaBE/+h7gZn7Li+Pya+DMk7tGxoIHNpPuGVTAyVhQbjWdQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.16.0"
+        "@wordpress/deprecated": "^4.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5689,9 +5689,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.16.0.tgz",
-      "integrity": "sha512-rlp7gZRRPsob8z+//tS8bHHRTlkRiOfbKA1SJmyfakU/p4fcEXskLfdq/0wGPZtoHnia6kLKUyFMWhIBe8SuYQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.17.0.tgz",
+      "integrity": "sha512-u/ocyrPV4MJIKxM1OJg+Q6yOBD0pIYi1jcXE1HVYnc/9Mte0IFlfovYRJj6oGUc7u4dM6AVE2BUCQMJgmG406Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5702,9 +5702,9 @@
       }
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.16.0.tgz",
-      "integrity": "sha512-xA1sbiQoqfk530JMAFGpThGbCjGeVaVitEdB3WYWnHY8JGmI6l5SeWaen2GlD4zbbCS+HE0Kn0sof1h5B9R26A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.17.0.tgz",
+      "integrity": "sha512-KhS+HyduYVHWbB/uHxQUC1wHMACx2BpP+4euMN8Kimy/rIsyOFrav9ueVGn7fHu9wu++swk8nUWFBip3GdsliA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5724,15 +5724,15 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.16.0.tgz",
-      "integrity": "sha512-1Db9jeu7dxil/fJqAiLN5dA6gwoHWcgMSqZJ4dmZ0kMDMs40rtm6o60GFmAQGlrj+mmUvhOHTTwrBdpyfuv4bA==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.17.0.tgz",
+      "integrity": "sha512-mRLFDPmZiI3+POi/iUGoof/9fQi4YTJ/RAuIUipr7yG7l4SwOoQy4eSJy6QTyqtJxZ+/7qA+b/+Ek15UzFst5Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.16.0",
+        "@wordpress/escape-html": "^3.17.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -5744,9 +5744,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.16.0.tgz",
-      "integrity": "sha512-Rb3nUsqK2tzLpKhSRO5IID5O+gvNlyHRkKVmTszTB+0vjK+yh0Mc4UPzdHksPo8K7KnlAFt3SgjcfWYo3LYyUA==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.17.0.tgz",
+      "integrity": "sha512-yOfJwgmrtIXQDwX6zTC0L7ymYBXz3K3hlW0nDdtYy+bCw5z0gbrEOnBotOD6YdXlejAgnaAH+K1VSf0xxG5uGA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5757,17 +5757,17 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.2.0.tgz",
-      "integrity": "sha512-JKs2tEpkg6txe1emR+P7gw9OrSXvu89TMHuN1uk0wxdJeEqoF7HcxTdJBEaMHCz5HFhBHeuI5vShtX/WN6jf3g==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.3.0.tgz",
+      "integrity": "sha512-EG8PvRceycpn9B5UniHRJSwitTwWwqtsF+gcg+BOT/tU/dmMaDTRqQdXnPOhw10Qg+QKqvBEl6IT+yRwTP5rsA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "7.25.7",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^8.16.0",
-        "@wordpress/prettier-config": "^4.16.0",
+        "@wordpress/babel-preset-default": "^8.17.0",
+        "@wordpress/prettier-config": "^4.17.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -5857,9 +5857,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.16.0.tgz",
-      "integrity": "sha512-W82L1PdIhJPNpEb2F+0NWzrDoUqZo6NnYID7qHCexBiagq4+QS4uydM6anyFvUNrpL51CmkCNu31Xi8HjpSTGg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.17.0.tgz",
+      "integrity": "sha512-LGOHGuwCXCevuzaFpM2sgyPZxf3H7tWaSKzlvDzx2kmwiWIrFug/yebywv4Cxsl82I5DfZkDpxXRpqTxXrC0Nw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5870,9 +5870,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.16.0.tgz",
-      "integrity": "sha512-wnCtif4GsQ3gZgINN2GK6+yLH+vIsW3ASvUfdUlxYMcvMagNhJsqaE6dqsnKkezD8q/WNL7zv82BDyGSLKeHNQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.17.0.tgz",
+      "integrity": "sha512-8cVD8KTxsKLHA9r6Lt3fkQoNBUQ6zMWdgaK1VNRYRJgTfx8C6FlNBjvHrIIgS0nJ43k9iAmAObGQiL3GkGVI1g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5883,13 +5883,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.16.0.tgz",
-      "integrity": "sha512-O4ZUvjS8AlYzTxvw7fmp3xk51rpKv1h2/dGFc/L+IB97UrCBAiC9HBv6FIHRF1gci4Vdu/QnCDw3qpC+N/2gCw==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.17.0.tgz",
+      "integrity": "sha512-aAsYls8sTTSEimsvjxBl9mCYbZYD3BddHVpuHgbBxzC+2SZE+JYJ+IpcwEghC712qo0jEkG8Vdzhqae1PL6vCQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.16.0",
+        "@wordpress/hooks": "^4.17.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -5904,14 +5904,14 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "10.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.16.0.tgz",
-      "integrity": "sha512-fHZujKpOkYD3JnPGCYqB1VafUiqsUOnpdVGdBd7En5ELwRg189a0NcI4EmM8OkeItNDml4LU/4nCCkypSy29eA==",
+      "version": "10.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.17.0.tgz",
+      "integrity": "sha512-qzWFrMfa5HZdGxGq7I+s9bmUJqZrFfx6ow/slY1USKJqp1uRHRekAbq6UrOrJscs8rSUQiV/aNNPDgSfqBEM6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/element": "^6.16.0",
-        "@wordpress/primitives": "^4.16.0"
+        "@wordpress/element": "^6.17.0",
+        "@wordpress/primitives": "^4.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5919,9 +5919,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.16.0.tgz",
-      "integrity": "sha512-9JI0bz7bQ9PdXPtXSnZXtbkyh0h7ZtojeG0lFtf9xtFkA56JUuMALa623v1YeuHKYbYmCc03/pqtpDKc/8QfVQ==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.17.0.tgz",
+      "integrity": "sha512-PRykD6MgDkptKsKwETjNHiQUVtaegXkREX6UetN1iL6u+2la4XC/naDHByq7TL+Cg4snyR+PlNdw45Y4dgMf5w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -5932,9 +5932,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.16.0.tgz",
-      "integrity": "sha512-GFwoPBeOir9lV0ZCrkOapl7us+NqYphjeTRhZajNYr+grUCtvJYY0XzGZd8QuXKD9R5yBK42jgb4/9vc5tL2TA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.17.0.tgz",
+      "integrity": "sha512-PksPaHIQN+gHycF+S4b4PcZ35xRef2nRo+sBJXolnAWhKi93IrBENFDHwdyaD7gVe7t8qJlXYd7vaF8A6Tqn2g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5950,13 +5950,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.16.0.tgz",
-      "integrity": "sha512-2GXwvdFiSjpzCxXs8TrzPqAechoCmWvWqijs1ONRDNm8HB6Vq+2sFo3ndCQ9ISQCb4fRUb2LF+/hgVRgIpDmVg==",
+      "version": "12.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.17.0.tgz",
+      "integrity": "sha512-T5LWyi2VEiYjW2RQwajRuHeSNeI2cXKX+OJzDb9+RwIhD3316ghcExynGNmpT2Umo9mvNjWBpD57EPwQAOdR1w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.16.0",
+        "@wordpress/jest-console": "^8.17.0",
         "babel-jest": "29.7.0"
       },
       "engines": {
@@ -5969,13 +5969,13 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.16.0.tgz",
-      "integrity": "sha512-T4kaFkw6R1VkcBk+F7B4gmzEhSPRJwpMdkP7roNvENzKGtXs49K4xO0koOZhWUlGpZvhPJ1WWERyoub8S7rX2A==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.17.0.tgz",
+      "integrity": "sha512-6aZ28uoCmzjXONpRVtDPjevkw834fhIRBnn2KQdzENMnPiQCNbiG71mPNxkTw1yRHRRT5ptHvOe49ztWm9KMcA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^5.16.0"
+        "@wordpress/i18n": "^5.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5983,9 +5983,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.16.0.tgz",
-      "integrity": "sha512-TCcaVQx76erSPWoGctLYUSCx2fOmT8vVBR2w8O/2q6+qEO4G4FiCYhj2tYliGNH/H9hQX/6QvfIRWIEoCnvMXQ==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.17.0.tgz",
+      "integrity": "sha512-j5G1/baTcd9YYwzPVBSsT6XlFMeKELxwIYsmtrv7p49WiygPlHt6Rz6aLpym6L7BRaJ64mqG2/dY5KcEYdoCTg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5997,13 +5997,13 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.16.0.tgz",
-      "integrity": "sha512-+rVpUQo+HXGFBvCLox45OxwT/U4hsDD8UpcDh8MAwFwrYf33GUGgdAhO5i4V3RyJiMmiZpsemkHFjlOg10kUjQ==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.17.0.tgz",
+      "integrity": "sha512-mpEPYNOC1PgQMFalIcp4rdlvMf3/Gppvn2NWzxPIoIxA/AYJEbwZ4ctPIbioXIWaubM1UizC6Z8+7S2huLsfUw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^5.16.0",
+        "@wordpress/base-styles": "^5.17.0",
         "autoprefixer": "^10.4.20"
       },
       "engines": {
@@ -6015,9 +6015,9 @@
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.16.0.tgz",
-      "integrity": "sha512-raaEW2x+pPfIYXF7RUJGEH8zeYWd4esIE0bJbKTAJV0yM+RE/DOWsGLGPiVvLEAAPg2AkIZ7oX0UPOYsBrsBqw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.17.0.tgz",
+      "integrity": "sha512-yoNJRCRMX27bvGyLzF2GunbPqksn6NJD1DDbV7a5j8gUvOZezN+5duAFApIDwaa4n3fxfIzf0wdoBxrMdnuBFg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -6029,13 +6029,13 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.16.0.tgz",
-      "integrity": "sha512-mf5LPcA500KOo/UPiwNanNlH6Satwf4xBB1DPzw4InE67eACvAlde3oSYsoE6Uce6+7URRIefg9j47yXP2jkxw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.17.0.tgz",
+      "integrity": "sha512-O1dysI/Y9xv5uUMllH2VIxuBDCOVUX8WmouE9KKr11Yv4gkHzxzaU2M5rFtu7RbUCv6jtkvjidy2cuZuNpEIHQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/element": "^6.16.0",
+        "@wordpress/element": "^6.17.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -6047,9 +6047,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.16.0.tgz",
-      "integrity": "sha512-YmVPE/kHmAIEYiSnnfxQI7JBAvXxlCyVoGlfWxCJ/IH8W7gbZtl1R+iuRvT8L4Cdr+sUybT68Ry+o4o39OqURg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.17.0.tgz",
+      "integrity": "sha512-WzQHNx6wjgbxhuaKErjIRLSL9E9La8slsAXRTQPmkgvKqa11Rh4RYl2FLUh8tABK3xo5HzaHCplkZSm2q5wlbg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
@@ -6061,9 +6061,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.16.0.tgz",
-      "integrity": "sha512-k/AQ11+vlbpSWhyOU5t8huoGdN+PursA8bUxVfhEnqcKRWTK+LKSmSEpdyL1sv6XJqznWYjgaNSdIxTkadsPpg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.17.0.tgz",
+      "integrity": "sha512-9NGPyuUvtJD0OjWJ/Cn+6Qhjb8hXhiJH4i80W7MFVHRgUZLc/Tu5BOg2+OnXMRSePbgYivo1NLEukqdXqse5IA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -6074,9 +6074,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.16.0.tgz",
-      "integrity": "sha512-piLnJnV+tzWOEPJPdp431TcaKRoCpgGJ309W+UxM7fRHrYH/XZcXD8a+0pq56Dh/1QFO1elXXhPzhZQknwtyYw==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.17.0.tgz",
+      "integrity": "sha512-RBUNOp+wSweymRB0+fThv1HKUf1c8GVMUT/Xv0kqtrRsGFD70ciwnnfVXnPY0V6po9Uzj5Bb4+2qO/l/e2IwXw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
@@ -6093,20 +6093,20 @@
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.16.0.tgz",
-      "integrity": "sha512-p+9WPzVo5pXLr1Xt04gQ1kdYQYmw05r2Kp42tgIfFNjgCBH1plpSrzjCyV/dyHrZ7APpJFg8sNjlOJmyLQiCFg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.17.0.tgz",
+      "integrity": "sha512-HEmApVDjConxYe3cP8P+Zs0xLJZPMhfWal38MQmFelQtCNk+kT0IBg5SkFAcWYY+c4gzhK+dMKawc72uWDfm8w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.16.0",
-        "@wordpress/compose": "^7.16.0",
-        "@wordpress/data": "^10.16.0",
-        "@wordpress/deprecated": "^4.16.0",
-        "@wordpress/element": "^6.16.0",
-        "@wordpress/escape-html": "^3.16.0",
-        "@wordpress/i18n": "^5.16.0",
-        "@wordpress/keycodes": "^4.16.0",
+        "@wordpress/a11y": "^4.17.0",
+        "@wordpress/compose": "^7.17.0",
+        "@wordpress/data": "^10.17.0",
+        "@wordpress/deprecated": "^4.17.0",
+        "@wordpress/element": "^6.17.0",
+        "@wordpress/escape-html": "^3.17.0",
+        "@wordpress/i18n": "^5.17.0",
+        "@wordpress/keycodes": "^4.17.0",
         "memize": "^2.1.0"
       },
       "engines": {
@@ -6118,25 +6118,25 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "30.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.9.0.tgz",
-      "integrity": "sha512-tyfzDlI4Zplnw5BdMaO5QgItzEU6FsxK3bf2yZrx+fLjKwLndiTWk6ObDEW+tIrwWpCZv8d54z9mNMwIwgXVow==",
+      "version": "30.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.10.0.tgz",
+      "integrity": "sha512-Rs5NBN2TSWAYsf4DAchbi0ZnBkOjEfKzDXZGNEbWuO2dpbpPXHn9puZe5tBNo2bOe09mf+dXfOUh0Z1puK7orw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.16.0",
-        "@wordpress/browserslist-config": "^6.16.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.16.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.16.0",
-        "@wordpress/eslint-plugin": "^22.2.0",
-        "@wordpress/jest-preset-default": "^12.16.0",
-        "@wordpress/npm-package-json-lint-config": "^5.16.0",
-        "@wordpress/postcss-plugins-preset": "^5.16.0",
-        "@wordpress/prettier-config": "^4.16.0",
-        "@wordpress/stylelint-config": "^23.8.0",
+        "@wordpress/babel-preset-default": "^8.17.0",
+        "@wordpress/browserslist-config": "^6.17.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.17.0",
+        "@wordpress/e2e-test-utils-playwright": "^1.17.0",
+        "@wordpress/eslint-plugin": "^22.3.0",
+        "@wordpress/jest-preset-default": "^12.17.0",
+        "@wordpress/npm-package-json-lint-config": "^5.17.0",
+        "@wordpress/postcss-plugins-preset": "^5.17.0",
+        "@wordpress/prettier-config": "^4.17.0",
+        "@wordpress/stylelint-config": "^23.9.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "29.7.0",
         "babel-loader": "9.2.1",
@@ -6216,9 +6216,9 @@
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.16.0.tgz",
-      "integrity": "sha512-T3KLZq5SYGigltEQumCKExKBJqnI2IF2elnJpd5+CFxQQAb9/gsrZ4TBG7ommOlXHZKn5hwD2YIEEM/ZAkGQ4A==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.17.0.tgz",
+      "integrity": "sha512-sNPUmeeK/dxK5z8BWSsk5OqRSf2UzfczpKu3upRn9eIdgG31SCXPgzvps73upIrxZNDCTQVVFhq47KADX8TiUA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
@@ -6230,9 +6230,9 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.8.0.tgz",
-      "integrity": "sha512-Fqf8GVZlaflq2n7JMxEk+KfVhgbDgdx/qs/R6ZxnR7RTC6c9RqGxSdUqdhtJyVkoNB3pWRG/aD1h7abKVEO3dA==",
+      "version": "23.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.9.0.tgz",
+      "integrity": "sha512-id+dU8JmvLBP/4Od0sIYe6g56nUKh97NO0RI+PNHDRB660Nn7nBJpRAu9Y3vd/3RwoZyaS72JAovmkQrzynGiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6249,13 +6249,13 @@
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.16.0.tgz",
-      "integrity": "sha512-IE3u5Yk8QzUhiLAiGmYostsygxQExs9mVWlZ1BAXniEGCAcVdvDv7IB16dIgQxCYG3/idvmFdNbN8aQGX+nEIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.17.0.tgz",
+      "integrity": "sha512-inSOCUneGMmFq3jRTB9uIws/+6VWpz0zvY2IPW/vjWbz7Gg1YbJ+lmbbgtJCoiJ7Ei00b4sagvzI00TNUXe9mg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/is-shallow-equal": "^5.16.0"
+        "@wordpress/is-shallow-equal": "^5.17.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -6263,9 +6263,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.16.0.tgz",
-      "integrity": "sha512-A9kkw/ye2qL9ZHvm1Eew8bvGVnNMq4fW0t5dakdDuVXyXtSOvZVT268JhP9QaD0FYzOFrmxL5Ks8Z6ufP1yLwg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.17.0.tgz",
+      "integrity": "sha512-aFU1w2Wcz2/YdapPYozeXbb7C7LzfYZmAg4Bu28zTSxxrpKYocr/oYH7D8V13uHzfBoqTzL8XYM7wj17Dlcdag==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "7.25.7",
@@ -6277,9 +6277,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.16.0.tgz",
-      "integrity": "sha512-XsgqRPvB+VSecXnD3VfvJJxhcdTTX4EkgdzvWspmQnw0rNCV636KByZVgolzYhvr3La9EgqO+MqXzwvPHg/xfQ==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.17.0.tgz",
+      "integrity": "sha512-dmEjDbYtfPD8rMRtSrLxoW3g8CLKl+vK5pdXvDvG0lBoRjqwtRPP4cgNBOC8cq8gXRCwh5NDDtM2C8MTjGjVsQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7249,9 +7249,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.4.tgz",
-      "integrity": "sha512-G6i3A74FjNq4nVrrSTUz5h3vgXzBJnjmWAVlBWaZETkgu+LgKd7AiyOml3EDJY1AHlIbBHKDXE+TUT53Ff8OaA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -7730,9 +7730,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001696",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7949,9 +7949,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8854,9 +8854,9 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-calc": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.0.tgz",
-      "integrity": "sha512-uQ/LDGsf3mgsSUEXmAt3VsCSHR3aKqtEIkmB+4PhzYwRYOW5MZs/GhCCFpsOtJJkP6EC6uGipbrnaTjqaJZcJw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10167,9 +10167,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.88",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
-      "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
+      "version": "1.5.91",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
+      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -11776,9 +11776,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13841,9 +13841,9 @@
       "license": "MIT"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -14611,13 +14611,13 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17165,9 +17165,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.46",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-      "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
+      "version": "0.5.47",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
+      "integrity": "sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -18455,14 +18455,14 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
-      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.50.0"
+        "playwright-core": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -18475,9 +18475,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
-      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -19605,13 +19605,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -20638,9 +20631,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -21670,14 +21663,13 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
-      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
@@ -22105,16 +22097,16 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.10.1.tgz",
-      "integrity": "sha512-CBqs0jecftIyhic6xba+4OvZUp4B0wNbX19w6Rq1fPo+lBDmTevk+olo8H7u/WQpTSDCDbBN4f3oocQurvXLTQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.11.0.tgz",
+      "integrity": "sha512-AvJ6LVzz2iXHxPlPTR9WVy73FC/vmohH54VySNlCKX1NIXNAeuzy/VbIkMJLMyw/xKYqkgY4kAgB+qy5BfCaCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.35.0",
-        "mdn-data": "^2.14.0",
+        "mdn-data": "^2.15.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-selector-parser": "^7.0.0",
@@ -22244,25 +22236,25 @@
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.5.tgz",
-      "integrity": "sha512-umpQsJrBNsdMDgreSryMEXvJh66XeLtZUwA8Gj7rHGearGufUFv6rB/bcXRFsiGWw/VeSUgUofF4Rf2UKEOrTA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.6.tgz",
+      "integrity": "sha512-0wvv16mVo9nN0Md3k7DMjgAPKG/TY4F/gYMBVb/wMThFRJvzrpaqBFqF6km9wf8QfYTN+mNg5aeaBLfy8k35uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.5"
+        "flat-cache": "^6.1.6"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.5.tgz",
-      "integrity": "sha512-QR+2kN38f8nMfiIQ1LHYjuDEmZNZVjxuxY+HufbS3BW0EX01Q5OnH7iduOYRutmgiXb797HAKcXUeXrvRjjgSQ==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.6.tgz",
+      "integrity": "sha512-F+CKgSwp0pzLx67u+Zy1aCueVWFAHWbXepvXlZ+bWVTaASbm5SyCnSJ80Fp1ePEmS57wU+Bf6cx6525qtMZ4lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.8.7",
+        "cacheable": "^1.8.8",
         "flatted": "^3.3.2",
-        "hookified": "^1.6.0"
+        "hookified": "^1.7.0"
       }
     },
     "node_modules/stylelint/node_modules/global-modules": {
@@ -22438,9 +22430,9 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
-      "integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22451,7 +22443,7 @@
         "node": ">=14.18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -22928,20 +22920,20 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.75",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.75.tgz",
-      "integrity": "sha512-AOvV5YYIAFFBfransBzSTyztkc3IMfz5Eq3YluaRiEu55nn43Fzaufx70UqEKYr8BoLCach4q8g/bg6e5+/aFw==",
+      "version": "6.1.76",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.76.tgz",
+      "integrity": "sha512-uzhJ02RaMzgQR3yPoeE65DrcHI6LoM4saUqXOt/b5hmb3+mc4YWpdSeAQqVqRUlQ14q8ZuLRWyBR1ictK1dzzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "6.1.75",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.75.tgz",
-      "integrity": "sha512-rCkEQd21uiOl+yKcX5DZ0mMd/DKl4f3NDTGH9zbSVG2tiRcJOx9MeBwPcbPr1u0kanopJnpzPEQJ+S2ky9iqFA==",
+      "version": "6.1.76",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.76.tgz",
+      "integrity": "sha512-RgyLN7i/wCF3dZCWi2Qwmk68lNnPjBanLDnn0aLqAAe0ZLMr7+j3BYIzNJ7+bc5XuqZ6lATnRwlH52gSQiKOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.75"
+        "tldts-core": "^6.1.76"
       }
     },
     "node_modules/tmpl": {
@@ -24705,14 +24697,14 @@
       "version": "1.1.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^5.16.0",
-        "@wordpress/blocks": "^14.5.0",
-        "@wordpress/i18n": "^5.16.0",
-        "@wordpress/icons": "^10.16.0"
+        "@wordpress/api-fetch": "^7.17.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^5.17.0",
+        "@wordpress/blocks": "^14.6.0",
+        "@wordpress/i18n": "^5.17.0",
+        "@wordpress/icons": "^10.17.0"
       },
       "devDependencies": {
-        "@wordpress/scripts": "^30.9.0"
+        "@wordpress/scripts": "^30.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@npmcli/fs": "^4",
     "@popperjs/core": "^2.11.8",
-    "@wordpress/components": "^29.2.0",
+    "@wordpress/components": "^29.3.0",
     "chart.js": "^4",
     "chartjs-plugin-annotation": "^3",
     "coffeescript": "^2.7.0",
@@ -57,7 +57,7 @@
     "@lodder/grunt-postcss": "^3.1",
     "@parcel/watcher": "^2.5",
     "@types/node": "^22",
-    "@wordpress/scripts": "^30.9.0",
+    "@wordpress/scripts": "^30.10.0",
     "autoprefixer": "^10.4",
     "css-minimizer-webpack-plugin": "^7.0",
     "eslint-plugin-prettier": "^5.2",

--- a/plugins/lwtv-plugin/php/blocks/package.json
+++ b/plugins/lwtv-plugin/php/blocks/package.json
@@ -19,13 +19,13 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
-		"@wordpress/api-fetch": "^7.16.0",
-		"@wordpress/babel-plugin-import-jsx-pragma": "^5.16.0",
-		"@wordpress/blocks": "^14.5.0",
-		"@wordpress/i18n": "^5.16.0",
-		"@wordpress/icons": "^10.16.0"
+		"@wordpress/api-fetch": "^7.17.0",
+		"@wordpress/babel-plugin-import-jsx-pragma": "^5.17.0",
+		"@wordpress/blocks": "^14.6.0",
+		"@wordpress/i18n": "^5.17.0",
+		"@wordpress/icons": "^10.17.0"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^30.9.0"
+		"@wordpress/scripts": "^30.10.0"
 	}
 }


### PR DESCRIPTION
The following package versions were changed:

phpunit/phpunit (11.5.3 => 11.5.6)

@wordpress/components: ^29.2.0 -> ^29.3.0
@wordpress/api-fetch: ^7.16.0 -> ^7.17.0
@wordpress/babel-plugin-import-jsx-pragma: ^5.16.0 -> ^5.17.0
@wordpress/blocks: ^14.5.0 -> ^14.6.0
@wordpress/i18n: ^5.16.0 -> ^5.17.0
@wordpress/icons: ^10.16.0 -> ^10.17.0
@wordpress/scripts: ^30.9.0 -> ^30.10.0