### PR TITLE
Update script params

### DIFF
--- a/cron/debug.sh
+++ b/cron/debug.sh
@@ -2,24 +2,23 @@
 export PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Define the UUID for this specific task
-UUID="8qGWpfC-UzrCZCyV"
+UUID="run-debug-checks"
 
 # Define the path to the ping.sh script
 # Assuming it's in the same directory.
-PING_SCRIPT="$(dirname "$0")/ping.sh"
+PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "debug-directory-failed"
+	$PING_SCRIPT "$UUID" "false"
 	exit 1
 }
 
 /usr/bin/wp lwtv generate debug --path=/home/wp_bg3hrq/lezwatchtv.com/
 
 if [ $? -eq 0 ]; then
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "up" "debug-completed"
+	SUCCEEDED="true"
 else
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "debug-failed"
+	SUCCEEDED="false"
 fi
+
+$PING_SCRIPT "$UUID" "$SUCCEEDED"

--- a/cron/hourly.sh
+++ b/cron/hourly.sh
@@ -2,24 +2,23 @@
 export PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Define the UUID for this specific task
-UUID="oz2Iox8OKnYD7uV2"
+UUID="due-now-hourly"
 
 # Define the path to the ping.sh script
 # Assuming it's in the same directory.
-PING_SCRIPT="$(dirname "$0")/ping.sh"
+PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "hourly-directory-failed"
+	$PING_SCRIPT "$UUID" "false"
 	exit 1
 }
 
 /usr/bin/wp lwtv generate cron hourly --path=/home/wp_bg3hrq/lezwatchtv.com/
 
 if [ $? -eq 0 ]; then
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "up" "hourly-completed"
+	SUCCEEDED="true"
 else
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "hourly-failed"
+	SUCCEEDED="false"
 fi
+
+$PING_SCRIPT "$UUID" "$SUCCEEDED"

--- a/cron/lists.sh
+++ b/cron/lists.sh
@@ -2,22 +2,23 @@
 export PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Define the UUID for this specific task
-UUID="n_XK3iMolnf23y6C"
+UUID="generate-lists"
 
 # Define the path to the ping.sh script
 # Assuming it's in the same directory.
-PING_SCRIPT="$(dirname "$0")/ping.sh"
+PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
-	$PING_SCRIPT "$UUID" "down" "lists-directory-failed"
+	$PING_SCRIPT "$UUID" "false"
 	exit 1
 }
 
 /usr/bin/wp lwtv generate lists --path=/home/wp_bg3hrq/lezwatchtv.com/
 
-# Call ping.sh with UUID, status, and message
 if [ $? -eq 0 ]; then
-	$PING_SCRIPT "$UUID" "up" "lists-completed"
+	SUCCEEDED="true"
 else
-	$PING_SCRIPT "$UUID" "down" "lists-failed"
+	SUCCEEDED="false"
 fi
+
+$PING_SCRIPT "$UUID" "$SUCCEEDED"

--- a/cron/ontheten.sh
+++ b/cron/ontheten.sh
@@ -2,24 +2,23 @@
 export PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Define the UUID for this specific task
-UUID="YOLHUVeoryV7I5GP"
+UUID="due-now-10-min"
 
 # Define the path to the ping.sh script
 # Assuming it's in the same directory.
-PING_SCRIPT="$(dirname "$0")/ping.sh"
+PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "ontheten-directory-failed"
+	$PING_SCRIPT "$UUID" "false"
 	exit 1
 }
 
 /usr/bin/wp cron event run --due-now --path=/home/wp_bg3hrq/lezwatchtv.com/
 
 if [ $? -eq 0 ]; then
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "up" "ontheten-completed"
+	SUCCEEDED="true"
 else
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "ontheten-failed"
+	SUCCEEDED="false"
 fi
+
+$PING_SCRIPT "$UUID" "$SUCCEEDED"

--- a/cron/otd.sh
+++ b/cron/otd.sh
@@ -2,24 +2,24 @@
 export PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Define the UUID for this specific task
-UUID="xrPNV40IWEd5ShDP"
+UUID="set-char-and-show-otd"
 
 # Define the path to the ping.sh script
 # Assuming it's in the same directory.
-PING_SCRIPT="$(dirname "$0")/ping.sh"
+PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
 	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "otd-directory-failed"
+	$PING_SCRIPT "$UUID" false
 	exit 1
 }
 
 /usr/bin/wp lwtv generate otd --path=/home/wp_bg3hrq/lezwatchtv.com/
 
 if [ $? -eq 0 ]; then
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "up" "otd-completed"
+	SUCCEEDED="true"
 else
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "otd-failed"
+	SUCCEEDED="false"
 fi
+
+$PING_SCRIPT "$UUID" "$SUCCEEDED"

--- a/cron/otd.sh
+++ b/cron/otd.sh
@@ -9,17 +9,17 @@ UUID="set-char-and-show-otd"
 PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" false
-	exit 1
+        # Call ping.sh with UUID, status, and message
+        $PING_SCRIPT "$UUID" "false"
+        exit 1
 }
 
 /usr/bin/wp lwtv generate otd --path=/home/wp_bg3hrq/lezwatchtv.com/
 
 if [ $? -eq 0 ]; then
-	SUCCEEDED="true"
+        SUCCEEDED="true"
 else
-	SUCCEEDED="false"
+        SUCCEEDED="false"
 fi
 
 $PING_SCRIPT "$UUID" "$SUCCEEDED"

--- a/cron/ping.sh
+++ b/cron/ping.sh
@@ -13,7 +13,7 @@ fi
 BASEURL="https://health.ipstenu.com/ping/YngRQgrkWz3aUQkrLjMrPg"
 STATUS=""
 
-if [ "$SUCCEEDED" != true ]; then
+if [ "$SUCCEEDED" != "true" ]; then
 	STATUS="/fail"
 fi
 

--- a/cron/ping.sh
+++ b/cron/ping.sh
@@ -2,16 +2,20 @@
 
 # Assign command-line arguments to variables
 UUID=$1
-STATUS=$2
-MESSAGE=$3
+SUCCEEDED=$2
 
 # Check if all arguments are provided
-if [ -z "$UUID" ] || [ -z "$STATUS" ] || [ -z "$MESSAGE" ]; then
-	echo "Usage: $0 <uuid> <status> <message>"
+if [ -z "$UUID" ] || [ -z "$SUCCEEDED" ]; then
+	echo "Usage: $0 <uuid> <succeeded: boolean>"
 	exit 1
 fi
 
-BASEURL="https://uptime.ipstenu.com/api/push/$UUID"
+BASEURL="https://health.ipstenu.com/ping/YngRQgrkWz3aUQkrLjMrPg"
+STATUS=""
+
+if [ "$SUCCEEDED" != true ]; then
+	STATUS="/fail"
+fi
 
 # Execute the curl command to send the ping
-/usr/bin/curl -fsS -m 10 --retry 5 -o /dev/null "$BASEURL?status=$STATUS&msg=$MESSAGE"
+/usr/bin/curl -X POST -m 10 --retry 5 -o /dev/null "$BASEURL/$UUID$STATUS"

--- a/cron/tvmaze.sh
+++ b/cron/tvmaze.sh
@@ -2,24 +2,23 @@
 export PATH="/usr/local/bin:/usr/bin:/bin"
 
 # Define the UUID for this specific task
-UUID="xrPNV40IWEd5ShDP"
+UUID="update-tvmaze"
 
 # Define the path to the ping.sh script
 # Assuming it's in the same directory.
-PING_SCRIPT="$(dirname "$0")/ping.sh"
+PING_SCRIPT="/home/wp_bg3hrq/cron/ping.sh"
 
 cd /home/wp_bg3hrq/lezwatchtv.com || {
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "tvmaze-directory-failed"
+	$PING_SCRIPT "$UUID" "false"
 	exit 1
 }
 
 /usr/bin/wp lwtv generate tvmaze --path=/home/wp_bg3hrq/lezwatchtv.com/
 
 if [ $? -eq 0 ]; then
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "up" "tvmaze-completed"
+	SUCCEEDED="true"
 else
-	# Call ping.sh with UUID, status, and message
-	$PING_SCRIPT "$UUID" "down" "tvmaze-failed"
+	SUCCEEDED="false"
 fi
+
+$PING_SCRIPT "$UUID" "$SUCCEEDED"


### PR DESCRIPTION
This pull request refactors all cron job scripts and the `ping.sh` script to simplify health check reporting and standardize their usage. The main improvements are switching from a multi-argument status/message ping to a boolean success indicator, updating script paths, and changing the health check endpoint. This streamlines monitoring and makes the scripts easier to maintain.

**Health check reporting and endpoint changes:**

* Refactored `cron/ping.sh` to accept only a UUID and a boolean success indicator, removed the message argument, and switched the health check endpoint from `uptime.ipstenu.com` to `health.ipstenu.com`. The script now sends a POST request with a `/fail` suffix only on failure.

**Standardization and simplification across all cron job scripts:**

* Updated all cron scripts (`debug.sh`, `hourly.sh`, `lists.sh`, `ontheten.sh`, `otd.sh`, `tvmaze.sh`) to use the new `ping.sh` interface, passing just the UUID and success boolean, and removed all custom status/message handling.
* Changed the path for `ping.sh` in all cron scripts to an absolute path (`/home/wp_bg3hrq/cron/ping.sh`) for consistency and reliability.
* Replaced hardcoded UUIDs with more descriptive names in all cron scripts to improve readability and maintainability. 