### PR TITLE
fix: improve clipboard copy error handling in Render component

### DIFF
--- a/plugins/lwtv-plugin/php/blocks/src/wikidata-actor/js/render.js
+++ b/plugins/lwtv-plugin/php/blocks/src/wikidata-actor/js/render.js
@@ -93,19 +93,14 @@ export default function Render() {
 
 	const handleCopy = async (textToCopy) => {
 		try {
-			// eslint-disable-next-line no-undef
 			if (
-				// eslint-disable-next-line no-undef
 				typeof navigator !== 'undefined' &&
-				// eslint-disable-next-line no-undef
 				navigator.clipboard &&
-				// eslint-disable-next-line no-undef
 				navigator.clipboard.writeText
 			) {
-				// eslint-disable-next-line no-undef
 				await navigator.clipboard.writeText(textToCopy);
 			} else {
-				// eslint-disable-next-line no-undef, no-alert
+				// eslint-disable-next-line no-alert
 				window.alert(
 					'Copy to clipboard is not supported in your browser. Please copy manually.'
 				);
@@ -115,7 +110,13 @@ export default function Render() {
 				setShowToast(false);
 			}, 2500);
 		} catch (err) {
-			// Silently fail if copy doesn't work
+			// Display error to user
+			// eslint-disable-next-line no-alert
+			window.alert('Error: ' + err.message || 'Unknown error');
+			setShowToast(true);
+			setTimeout(() => {
+				setShowToast(false);
+			}, 2500);
 		}
 	};
 


### PR DESCRIPTION
Updated the clipboard copy functionality to provide user feedback in case of errors. Instead of silently failing, the application now alerts the user with the error message when the copy operation fails. This enhances the user experience by informing them of issues directly.

- Removed unnecessary eslint-disable comments for cleaner code.
- Added error alert to notify users of clipboard copy failures.
