### PR TITLE
fix: repair stale BYQ cache causing first dead character to persist

### DIFF
--- a/plugins/lwtv-plugin/php/rest-api/class-byq.php
+++ b/plugins/lwtv-plugin/php/rest-api/class-byq.php
@@ -145,8 +145,10 @@ class BYQ {
 		$cache_key   = 'byq_death_list_' . $this->get_data_version_hash();
 		$cached_list = lwtv_plugin()->get_transient( $cache_key );
 
-		// If there is no current filter, we're on a page load, so we can check the cache
-		if ( empty( $wp_current_filter ) ) {
+		// If there is no current filter we're on a page load — but REST API requests may also
+		// have an empty filter stack and must be allowed to regenerate the list directly.
+		$is_rest = defined( 'REST_REQUEST' ) && REST_REQUEST;
+		if ( empty( $wp_current_filter ) && ! $is_rest ) {
 			lwtv_plugin()->debug_log( 'buryqueers', 'wp_current_filter is empty' );
 			if ( false !== $cached_list ) {
 				lwtv_plugin()->debug_log( 'buryqueers', 'Returning cached death list check on page load.' );
@@ -367,11 +369,17 @@ class BYQ {
 
 		$cache_key     = 'byq_last_death_' . $this->get_data_version_hash();
 		$cached_result = lwtv_plugin()->get_transient( $cache_key );
-		// ID 83580 is Frankie, the first dead character we added. When this is finally fixed, we can
-		// remove this check. For now, we know if Frankie is NOT the last death, we should be okay.
-		if ( false !== $cached_result && ! is_wp_error( $cached_result ) && '83580' !== $cached_result['id'] ) {
-			lwtv_plugin()->debug_log( 'buryqueers', 'Returning cached last death: ' . wp_json_encode( $cached_result ) );
-			return $cached_result;
+		if ( false !== $cached_result && ! is_wp_error( $cached_result ) ) {
+			// 83580 is Frankie, the first dead character added — if she appears as "last death"
+			// the death_list cache has stale/wrong data; purge both caches and regenerate.
+			if ( 83580 === (int) $cached_result['id'] ) {
+				lwtv_plugin()->debug_log( 'buryqueers', 'Stale Frankie data detected in last_death cache — purging and regenerating' );
+				delete_transient( $cache_key );
+				delete_transient( 'byq_death_list_' . $this->get_data_version_hash() );
+			} else {
+				lwtv_plugin()->debug_log( 'buryqueers', 'Returning cached last death: ' . wp_json_encode( $cached_result ) );
+				return $cached_result;
+			}
 		} else {
 			lwtv_plugin()->debug_log( 'buryqueers', 'No cached last death found, generating new one' );
 		}
@@ -640,9 +648,6 @@ class BYQ {
 		);
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- query built with prepare() above
-		$results = $wpdb->get_results( $query );
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- IDs are sanitized integers
 		$results = $wpdb->get_results( $query );
 
 		lwtv_plugin()->debug_log( 'buryqueers', 'Bulk meta query results count: ' . count( $results ) );


### PR DESCRIPTION
The `/last-death` REST API endpoint was periodically reverting to Frankie (the first dead character ever added, ID 83580) and staying stuck there until the object cache was manually flushed. Four compounding bugs in `class-byq.php` caused this: a broken type comparison that prevented the existing guard from ever firing, missing invalidation of the underlying death list cache, incorrect early-bail behaviour during REST API requests, and a duplicate database query.

### Changes

- **Fix Frankie guard type comparison:** Change `'83580' !== $cached_result['id']` to `83580 === (int) $cached_result['id']` — the previous strict `!==` between a string literal and an integer ID always evaluated to `true`, so stale Frankie data was always returned from cache unchallenged.
- **Purge both stale caches on detection:** When Frankie is detected as the cached last death, explicitly delete both the `byq_last_death_*` and `byq_death_list_*` transients before regenerating. Without this, regeneration would re-read the same stale death list and re-cache Frankie on the next write.
- **Allow REST API requests to bypass the empty-filter guard:** `list_of_dead_characters()` returned an empty array and deferred to an Action Scheduler task when `$wp_current_filter` was empty. REST API callbacks can run with an empty filter stack, so the endpoint was silently returning nothing and leaving caches inconsistent. Add `&& ! $is_rest` (using `REST_REQUEST`) so REST requests regenerate in-request.
- **Remove duplicate DB query:** `get_bulk_death_meta_data()` called `$wpdb->get_results()` twice in a row; the first result was immediately overwritten. Remove the redundant call.

### Testing instructions

1. Confirm the endpoint returns the correct most-recent death: `curl https://lezwatchtv.com/wp-json/lwtv/v1/last-death`
2. Flush the object cache (e.g. via WP-CLI `wp cache flush`) and hit the endpoint again — it should regenerate with the correct character, not Frankie.
3. Save any dead character post (to trigger cache invalidation) and re-check the endpoint within a minute — it should still reflect the correct last death.
4. Check the UptimeKuma monitor — it should stop alerting on stale/wrong data.
