### PR TITLE
fix: handle Action Scheduler breaking changes for failed action retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [7.0.4] - 2026-06-17
+
+### Fixed
+
+- Failed Action Scheduler actions now respect the configured 3-day retention period after the Action Scheduler update introduced a dedicated `action_scheduler_retention_period_for_failed` filter
+
 ## [7.0.3] - 2026-06-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwtv-underscores",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "LezWatch.TV Custom Theme.",
   "main": "index.js",
   "workspaces": [

--- a/plugins/lwtv-plugin/php/plugins/class-actionscheduler.php
+++ b/plugins/lwtv-plugin/php/plugins/class-actionscheduler.php
@@ -36,6 +36,13 @@ class ActionScheduler {
 	private $retention_period = 3 * DAY_IN_SECONDS;
 
 	/**
+	 * Retention period for failed actions
+	 *
+	 * @var int
+	 */
+	private $retention_period_for_failed = 3 * DAY_IN_SECONDS;
+
+	/**
 	 * Concurrent queues
 	 *
 	 * @var int
@@ -58,6 +65,7 @@ class ActionScheduler {
 	private function run_filters() {
 		$this->cleanup_batch_size();
 		$this->retention_period();
+		$this->retention_period_for_failed();
 		$this->default_cleaner_statuses();
 		$this->aioseo_seo_analyzer_next_scan();
 		$this->concurrent_queues();
@@ -88,7 +96,19 @@ class ActionScheduler {
 	}
 
 	/**
-	 * Tell AS to clean up failed actions
+	 * Adjust retention period for failed actions (AS 3.x dedicated filter)
+	 */
+	private function retention_period_for_failed() {
+		add_filter(
+			'action_scheduler_retention_period_for_failed',
+			function () {
+				return $this->retention_period_for_failed;
+			}
+		);
+	}
+
+	/**
+	 * Tell AS to clean up failed actions (safety net for older AS versions)
 	 */
 	private function default_cleaner_statuses() {
 		add_filter(


### PR DESCRIPTION
Action Scheduler introduced a dedicated `action_scheduler_retention_period_for_failed` filter to control failed action cleanup separately from the general retention period. Without explicitly setting this filter, failed actions would accumulate for the new 3-month default instead of the intended 3-day cycle. This patch ensures the existing cleanup behavior is preserved across the update.

### Changes

- **Add `$retention_period_for_failed` property** to `ActionScheduler` class, mirroring the existing 3-day general retention period.
- **Add `retention_period_for_failed()` method** that filters `action_scheduler_retention_period_for_failed` to enforce 3-day cleanup of failed actions via the new dedicated filter.
- **Wire into `run_filters()`** so the new filter is registered alongside all other ActionScheduler tuning filters.
- **Update `default_cleaner_statuses()` comment** to clarify it now acts as a safety net for older AS versions rather than the primary cleanup mechanism.
- **Bump version** to `7.0.4`.