### PR TITLE
chore: bump deps, fix FacetWP ACF compat, add weekly reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.9] - 2026-06-25
+
+### Changed
+
+- WP-CLI weekly debug cron consolidates actor checks (problems + iMDB) on Thursdays and shows checks (problems + iMDB) on Saturdays; Sundays now trigger a FacetWP force re-index instead.
+
+### Fixed
+
+- "Shows We Love" FacetWP facet now correctly indexes shows flagged as loved; ACF stores the `true_false` field as `1` rather than the legacy `on` value, which had caused all loved shows to be indexed as `no`.
+
 ## [7.0.8] - 2026-06-19
 
 ### Fixed

--- a/cron/ping.sh
+++ b/cron/ping.sh
@@ -10,7 +10,7 @@ if [ -z "$UUID" ] || [ -z "$SUCCEEDED" ]; then
 	exit 1
 fi
 
-BASEURL="https://health.ipstenu.com/ping/YngRQgrkWz3aUQkrLjMrPg"
+BASEURL="https://health.ipstenu.com/ping/wxhnd3lkkwsuh6rxgtqnsa"
 STATUS=""
 
 if [ "$SUCCEEDED" != "true" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lwtv-underscores",
-  "version": "7.0.1",
+  "version": "7.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lwtv-underscores",
-      "version": "7.0.1",
+      "version": "7.0.9",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "workspaces": [
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@parcel/watcher": "^2",
         "@types/node": "^22",
-        "@wordpress/scripts": "^32.4.1",
+        "@wordpress/scripts": "^32.5.0",
         "autoprefixer": "^10.4",
         "css-minimizer-webpack-plugin": "^8.0",
         "eslint-plugin-prettier": "^5.5",
@@ -40,22 +40,22 @@
       }
     },
     "node_modules/@ariakit/components": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.2.tgz",
-      "integrity": "sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.3.tgz",
+      "integrity": "sha512-l22VB1g0Dz6zrKyDjykg8uXemUGolaeJjcLKf9XY5iSxzuU0PZTLSmRfJFq4pjTHsRroL4HM96f6J0Pivu2oOg==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/store": "0.1.2",
-        "@ariakit/utils": "0.1.2"
+        "@ariakit/store": "0.1.3",
+        "@ariakit/utils": "0.1.3"
       }
     },
     "node_modules/@ariakit/react": {
-      "version": "0.4.29",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
-      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
+      "version": "0.4.30",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.30.tgz",
+      "integrity": "sha512-7QAS4uAoSp1Avekp1ve8xLRPm4E7wLIQFfYM08cHfgMfBBGQGkxrXFqP3QmqEMTUa99H4ZHK9unL05+752cBhQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-components": "0.1.2"
+        "@ariakit/react-components": "0.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -67,16 +67,16 @@
       }
     },
     "node_modules/@ariakit/react-components": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.1.2.tgz",
-      "integrity": "sha512-SM+SPMAVlOZmGAfWNBza+0k9y4mkA5/dJhDoOyhE96cbNARy665uLdwowSJl1JGuFfcZzuzAwGon7f/rYeyfkQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.2.0.tgz",
+      "integrity": "sha512-hoAwGSh5xQ0va4oWSTOmoNIIDS+90eVzg6XceCC9WMyhRn1I1YVluxCqltZ9UY+6vzu7PpJDvC4g5N2rmCh6og==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/components": "0.1.2",
-        "@ariakit/react-store": "0.1.2",
-        "@ariakit/react-utils": "0.1.2",
-        "@ariakit/store": "0.1.2",
-        "@ariakit/utils": "0.1.2",
+        "@ariakit/components": "0.1.3",
+        "@ariakit/react-store": "0.1.3",
+        "@ariakit/react-utils": "0.1.3",
+        "@ariakit/store": "0.1.3",
+        "@ariakit/utils": "0.1.3",
         "@floating-ui/dom": "^1.0.0"
       },
       "peerDependencies": {
@@ -85,14 +85,14 @@
       }
     },
     "node_modules/@ariakit/react-store": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.2.tgz",
-      "integrity": "sha512-1r1Gn0tqhnOS0LFvHNGzn5/8C5aOANO5vb0Gxh94oR/be4zwCSE2zfQjOjRfpL+BBDhOcProME2+G6UslEJxbg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.3.tgz",
+      "integrity": "sha512-x8kjHcDoEkTX5bu3qkSfnvRCZuqXtjQZ1seohIWq8NPAfB0qe6q3GlGwCVCXw62Tlcf44SwxpuRQYQyj0/eurw==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-utils": "0.1.2",
-        "@ariakit/store": "0.1.2",
-        "@ariakit/utils": "0.1.2",
+        "@ariakit/react-utils": "0.1.3",
+        "@ariakit/store": "0.1.3",
+        "@ariakit/utils": "0.1.3",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -100,31 +100,31 @@
       }
     },
     "node_modules/@ariakit/react-utils": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.2.tgz",
-      "integrity": "sha512-Rnl6D1542Mqu80xK++oUv1JXS0PtNmKXd9nkdud5nyvySiBDTrmPqRW44/D+5GbuZrboreQuY3tPYwKL7a7onQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.3.tgz",
+      "integrity": "sha512-eaqLU+7lknPWzcWK7CYQw9Mu52c6If3jc8wm08Fw/hobOCeeG97Z865PQeNYQMK7BYqb01ByVNaIPEWYwcPkfw==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/store": "0.1.2",
-        "@ariakit/utils": "0.1.2"
+        "@ariakit/store": "0.1.3",
+        "@ariakit/utils": "0.1.3"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@ariakit/store": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.2.tgz",
-      "integrity": "sha512-SS7bV4+a+1q9M9i0WV6DD4P/ypRKlCvII8soo2UMe1yuaxZA/Fc0htHe+EZwjJ6TMLjHfHh2TDSnXyrjC7QImA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.3.tgz",
+      "integrity": "sha512-EAKGIUbHGKH9Kx53ae17+5l/b/z1VUKqiyHcV675AKn1ed1qsLEHX2KovFf+eHLtGBgINSd0NXv11LIe3x/uFA==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/utils": "0.1.2"
+        "@ariakit/utils": "0.1.3"
       }
     },
     "node_modules/@ariakit/utils": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.2.tgz",
-      "integrity": "sha512-lBJhtBWpKjIck/9i7G8cahvaUgLsyGklI/Pjv+VtY9KTzyuzX5GpRbbLKMS/e1qLnFPS4C3CybYB70b1bVcAkw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.3.tgz",
+      "integrity": "sha512-OMdM631rIiDLYr1nnd1vtGyLvlYt08APMa2TJACA8Myn80PF+XtH9ZLBXTVUuUnlrYVyY2duX+EOkg6z9/NeCA==",
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2097,13 +2097,13 @@
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
-      "integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.2.9",
+        "@base-ui/utils": "0.3.1",
         "@floating-ui/react-dom": "^2.1.8",
         "@floating-ui/utils": "^0.2.11",
         "use-sync-external-store": "^1.6.0"
@@ -2135,14 +2135,14 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.1.1",
+        "reselect": "^5.2.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@colordx/core": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
-      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3636,9 +3636,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3869,14 +3869,14 @@
       "link": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -4187,9 +4187,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4431,9 +4431,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4886,14 +4886,14 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4985,9 +4985,9 @@
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
-      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.3.tgz",
+      "integrity": "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -5031,9 +5031,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5982,9 +5982,9 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.170.15",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.15.tgz",
-      "integrity": "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==",
+      "version": "1.170.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.16.tgz",
+      "integrity": "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.0",
@@ -6059,9 +6059,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6332,9 +6332,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6555,17 +6555,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
-      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/type-utils": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6578,22 +6578,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.1",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6609,14 +6609,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.1",
-        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6631,14 +6631,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6649,9 +6649,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6666,15 +6666,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
-      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6691,9 +6691,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6705,16 +6705,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.1",
-        "@typescript-eslint/tsconfig-utils": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6772,9 +6772,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6785,16 +6785,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6809,13 +6809,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7416,13 +7416,13 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.48.1.tgz",
-      "integrity": "sha512-BPU7wRoz2XRmP3ZgVtENPKS4iO5/+bKNid/xLrvD6cP1qMhIGowQsBNqmkP1V5+q71hQM/ID6tpFjeLhmogfPg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.49.0.tgz",
+      "integrity": "sha512-owb2VJYS54F6R0cjxZzb/Jp+ogGaMpSkuZAWG8VqMW6I8PnFCva+6H4PP3flF7QnaiCvvgEIl2grsSJmUm9O7g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1"
+        "@wordpress/dom-ready": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7430,19 +7430,18 @@
       }
     },
     "node_modules/@wordpress/admin-ui": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.3.1.tgz",
-      "integrity": "sha512-bmC2OqpXNPqMBZkVMXy4DNZC0Td8hM5Z2dH13a+F6j2NeeftkfduGofEJiONFgqFMzw3zEt3tz/JdaQ+ydRSyA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.4.0.tgz",
+      "integrity": "sha512-ybYRlXS/hhppzv/ihPx9srqnqkbnmdjZajGH27VxdP0x1mbbfryzzfpOkBSXx5ydISK+JN8I3raKDQ9VYaMrTQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/route": "^0.14.1",
-        "@wordpress/style-runtime": "^0.4.1",
-        "@wordpress/ui": "^0.15.1",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/route": "^0.15.0",
+        "@wordpress/style-runtime": "^0.5.0",
+        "@wordpress/ui": "^0.16.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -7450,18 +7449,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.48.1.tgz",
-      "integrity": "sha512-RyEEY5C1XGLxJnluYFGVz4xFiw0jFjwL9Oiu4rDZjCGcxyu0sD6HPBcG6sIRpFKv062cwLccwpCeD8rc8U6Ctg==",
+      "version": "7.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.49.0.tgz",
+      "integrity": "sha512-SJTVvKAfpXScMoo3NTrY8PPlY2r+nQ9cF+In7mdoHtm9bZrSwYlGCgXGkzNGcTWEjAcu+hzzdj60gcnejPKoJA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/url": "^4.48.1"
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/url": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7469,9 +7474,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.48.1.tgz",
-      "integrity": "sha512-vMOdHhXIv559fYsg72AnWACblxZdojIerVeWxlX7a/ptoZK8MjqA0ZVhFsHezTBqdfiFyoRtiRECSFYLXWlSZg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.49.0.tgz",
+      "integrity": "sha512-2JmZWZI5GLLEoRdU1HO8zXUBi+2GR29cjoAomFdGqyr79zNqxpjHoZX0DH9auvMReSm9op8Dq97rSK+4aaQ0zQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7479,9 +7484,9 @@
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.48.1.tgz",
-      "integrity": "sha512-bX2pin6ooB8kT0dHTPL/q/G0ao3AQFHZeo8wWTxV2eAogx0U4mWIoo2Vk4OXVJJI5D3asTSXzB83bxxchbM+bg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.49.0.tgz",
+      "integrity": "sha512-y0flsOCZAuVJQpmBp2tWo0kkugxNqTYijfVLamMaXMYJZPxNkHf5D4UA3grsjZtPtJAixFFsOvf8Z10iUQgPIg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7492,9 +7497,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.48.1.tgz",
-      "integrity": "sha512-wC8l2sMR8XJO7ck4rHnYUm+287iN24CzsGejlw64hetRP2Oz/QeAXp2jbghRb4qW+2Ab6hLPtTEuJQlevvA1Yg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.49.0.tgz",
+      "integrity": "sha512-maJY07MuypSy2sHIdzVODKw9WCO0296PvTsMtZ7b19p6HfHHN3/aPzdk+MWC1w+FcAZStCjVCjHVuVvg4r6coA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7504,8 +7509,8 @@
         "@babel/plugin-transform-runtime": "^7.25.7",
         "@babel/preset-env": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@wordpress/browserslist-config": "^6.48.1",
-        "@wordpress/warning": "^3.48.1",
+        "@wordpress/browserslist-config": "^6.49.0",
+        "@wordpress/warning": "^3.49.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.1"
@@ -7516,9 +7521,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.0.1.tgz",
-      "integrity": "sha512-Kkayj4f6KzcMW2TFaahADE0aoDpYeqadIinvIp0hxY6+zn/uqK1Ml7x5idLZ/jbyzzbVlI31eid3HtblGY3+og==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
+      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7526,9 +7531,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.48.1.tgz",
-      "integrity": "sha512-iK3dtZu/UtnYpKfQ2aGZM2xrLXK5ff88QNU77XlraipaGV/C7zK2M0+sWY6cVL50TfMR7VX9prZ2XCpE5aRzSg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.49.0.tgz",
+      "integrity": "sha512-SZNwHk48d9+FNv8LzWJ3PPE9UbJb6BDuiE2sLEv8EvpxWAEQylJmkfWvC3Weegrdz1fn9SeBgtQevjMqfde8uQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7536,50 +7541,49 @@
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.21.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.21.1.tgz",
-      "integrity": "sha512-LCHp/NoYsR7MV0e7vPNBAgtjHqK3ST4VtduxF5nOgxl0K0zuyvDvanb14EQtY4KmR2Gjndgo72/aZ/kfdQbddg==",
+      "version": "15.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.22.0.tgz",
+      "integrity": "sha512-Brbe0tyL3ekEku6ljbZCTfMFyL3WmIiS55YCsU3zp4LxO9GdY754mzpVkS9/Rzc/pyBSvQJ1mGqSLEOkEMJrRw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/blob": "^4.48.1",
-        "@wordpress/block-serialization-default-parser": "^5.48.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/commands": "^1.48.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/dom": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/escape-html": "^3.48.1",
-        "@wordpress/global-styles-engine": "^1.15.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/image-cropper": "^1.12.1",
-        "@wordpress/interactivity": "^6.48.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "@wordpress/keyboard-shortcuts": "^5.48.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/preferences": "^4.48.1",
-        "@wordpress/priority-queue": "^3.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/rich-text": "^7.48.1",
-        "@wordpress/style-engine": "^2.48.1",
-        "@wordpress/token-list": "^3.48.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/upload-media": "^0.33.1",
-        "@wordpress/url": "^4.48.1",
-        "@wordpress/warning": "^3.48.1",
-        "@wordpress/wordcount": "^4.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/blob": "^4.49.0",
+        "@wordpress/block-serialization-default-parser": "^5.49.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/commands": "^1.49.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/dom": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/escape-html": "^3.49.0",
+        "@wordpress/global-styles-engine": "^1.16.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/image-cropper": "^1.13.0",
+        "@wordpress/interactivity": "^6.49.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/keyboard-shortcuts": "^5.49.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/preferences": "^4.49.0",
+        "@wordpress/priority-queue": "^3.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/rich-text": "^7.49.0",
+        "@wordpress/style-engine": "^2.49.0",
+        "@wordpress/token-list": "^3.49.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/upload-media": "^0.34.0",
+        "@wordpress/url": "^4.49.0",
+        "@wordpress/warning": "^3.49.0",
+        "@wordpress/wordcount": "^4.49.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
@@ -7600,14 +7604,20 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.48.1.tgz",
-      "integrity": "sha512-REsjN6tT2lXekrjuiu2O0+FYW13QHhy23j7C458zzSjpYcxROtl/T8AozOJYRvG9SkdC9Og3PkEP/9/nGC4IVw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
+      "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7615,36 +7625,35 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.21.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.21.1.tgz",
-      "integrity": "sha512-9VOQGCuDbmyBEp7/+HNgLKscOJfrqMEV6LYpOjF+LehZ7RwolqR03UGuU+xLSPKSVZw0wvmA0SjTm3a2GBxwjg==",
+      "version": "15.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
+      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/autop": "^4.48.1",
-        "@wordpress/blob": "^4.48.1",
-        "@wordpress/block-serialization-default-parser": "^5.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/dom": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/rich-text": "^7.48.1",
-        "@wordpress/shortcode": "^4.48.1",
-        "@wordpress/warning": "^3.48.1",
+        "@wordpress/autop": "^4.49.0",
+        "@wordpress/blob": "^4.49.0",
+        "@wordpress/block-serialization-default-parser": "^5.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/dom": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/rich-text": "^7.49.0",
+        "@wordpress/shortcode": "^4.49.0",
+        "@wordpress/warning": "^3.49.0",
         "change-case": "^4.1.2",
         "colord": "^2.9.3",
         "fast-deep-equal": "^3.1.3",
         "hpq": "^1.3.0",
         "is-plain-object": "^5.0.0",
+        "marked": "^18.0.3",
         "memize": "^2.1.0",
         "react-is": "^18.3.0",
         "remove-accents": "^0.5.0",
-        "showdown": "^1.9.1",
         "simple-html-tokenizer": "^0.5.7",
         "uuid": "^14.0.0"
       },
@@ -7653,13 +7662,19 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.48.1.tgz",
-      "integrity": "sha512-Rbh//p4Ugzw2xoKhBurtRXp/UxKxPAAPrtFAYDAXyByxIjEbEzvngHAYdFPn1VcwNxxB9qsEnzIaiZrgn2E2Qg==",
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.49.0.tgz",
+      "integrity": "sha512-q1gAcPttohpcmmLFG8nghrsHxCq/LD6ImHfNx0aV/vHc1/bBu3B7MF/E6fqG4WocqHNZbEGfs/a5ktQ4PWu4qw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7668,21 +7683,21 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.48.1.tgz",
-      "integrity": "sha512-yFmQ2yB4tOWPqhO+tE8uYyFqcGwxtOJ9uc1yHYfH40oMls3p+TswktsdbBM2gEmoYxfD+d3Nhp/mXGS38pdTdw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.49.0.tgz",
+      "integrity": "sha512-lEaISg3cpqn6AgPn/WBZSPsiwKZoCU2xfMQbvDtzGldN70Er40Frgf35xnFk/thlXUxL/L9dIB7a7wkZcOQ68w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/keyboard-shortcuts": "^5.48.1",
-        "@wordpress/preferences": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/warning": "^3.48.1",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.49.0",
+        "@wordpress/preferences": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/warning": "^3.49.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -7696,12 +7711,12 @@
       }
     },
     "node_modules/@wordpress/components": {
-      "version": "35.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.1.tgz",
-      "integrity": "sha512-EiTeufX2spZ09kjI8Aa4c7dG6A3WyRSGyHTcCsVnIoE/ykOnAjtGSxnVRAT1KefrJ9RGI8JaTld48wjrB/CS5A==",
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
+      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ariakit/react": "^0.4.21",
+        "@ariakit/react": "^0.4.29",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
@@ -7712,28 +7727,27 @@
         "@floating-ui/react-dom": "^2.0.8",
         "@types/gradient-parser": "^1.1.0",
         "@types/highlight-words-core": "^1.2.1",
-        "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/dom": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/escape-html": "^3.48.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/primitives": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/rich-text": "^7.48.1",
-        "@wordpress/style-runtime": "^0.4.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/warning": "^3.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/dom": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/escape-html": "^3.49.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/primitives": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/rich-text": "^7.49.0",
+        "@wordpress/style-runtime": "^0.5.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/warning": "^3.49.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
@@ -7758,8 +7772,14 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/components/node_modules/path-to-regexp": {
@@ -7769,21 +7789,20 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/compose": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.1.tgz",
-      "integrity": "sha512-AEC9yOS5CuTk34F+oiWebhQrxgICnb/v/KScQBUVm6zbs1AMFtu5ku+Zk0A3YTD0tO/hNzXLbvsXhJdh1bGkRA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@types/react": "^18.3.27",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/dom": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/priority-queue": "^3.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/undo-manager": "^1.48.1",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/dom": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/priority-queue": "^3.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/undo-manager": "^1.49.0",
         "change-case": "^4.1.2",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
@@ -7793,32 +7812,37 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.48.1.tgz",
-      "integrity": "sha512-ITnh9M8RStzvl4+zSlz0ORPWih3VXChN5X+hYEHj80KlB+pBBOuE+JghTPF3wYEH/VmYxDV1IJmsuOC2luor+w==",
+      "version": "7.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.49.0.tgz",
+      "integrity": "sha512-kKDpZ196QEvcjK5PUz0EwxQXBDaXCFHHCpl/ZBIOV8hdBR6KBSn632J8RMlBlLFnOzzunnHrYPE9Q0LDeygYuA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/block-editor": "^15.21.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/rich-text": "^7.48.1",
-        "@wordpress/sync": "^1.48.1",
-        "@wordpress/undo-manager": "^1.48.1",
-        "@wordpress/url": "^4.48.1",
-        "@wordpress/warning": "^3.48.1",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/block-editor": "^15.22.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/rich-text": "^7.49.0",
+        "@wordpress/sync": "^1.49.0",
+        "@wordpress/undo-manager": "^1.49.0",
+        "@wordpress/url": "^4.49.0",
+        "@wordpress/warning": "^3.49.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -7830,24 +7854,29 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.1.tgz",
-      "integrity": "sha512-74p4PiDLxS0SAd4tdkPEUF5rtHVtdRzoXExfhkZaumviE56tEceG07YbLjQWpZ+Vl1tZCvkyqLbMHK+Wj6ZerQ==",
+      "version": "10.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
+      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "@wordpress/priority-queue": "^3.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/redux-routine": "^5.48.1",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/priority-queue": "^3.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/redux-routine": "^5.49.0",
         "deepmerge": "^4.3.1",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -7861,31 +7890,36 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.1.tgz",
-      "integrity": "sha512-OyDOPvtCIL0AV4wTGSrFHhBVEYwkBJvmfleSjXzGWc09u3BPIiefazoGN4GvtJPJbvieSyelXuVyN+JARIRUug==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.0.0.tgz",
+      "integrity": "sha512-d+0tCa0xWP1QXbEdXesp0wlthRmSAXtp1X0bkVnlDlJdGbY2s7crgUMALQJ/R37Wkch3B1IdNBaa8GM+nc3z1A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ariakit/react": "^0.4.21",
-        "@types/react": "^18.3.27",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/primitives": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/warning": "^3.48.1",
+        "@ariakit/react": "^0.4.29",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/primitives": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/warning": "^3.49.0",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
         "date-fns": "^4.1.0",
@@ -7898,17 +7932,23 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.48.1.tgz",
-      "integrity": "sha512-SD6AzzmxtsrTbSkZFV6nklYzYgZFDuCxX41kxRmIQGTBNP0f4DvLjwlUCpLN/lHEerctx4XdkZAghvGOHOKvbg==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.49.0.tgz",
+      "integrity": "sha512-6Q7tvwjwNI2W0KDIATd4WAOc1n5Ppp/v/ofOwPjvaXr/9O4s2fsduR//ziQL3c5a5oYohCIsNHSHmOic+/Jofg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.48.1",
+        "@wordpress/deprecated": "^4.49.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -7918,9 +7958,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.48.1.tgz",
-      "integrity": "sha512-mot0QEwrPhxmaCEzl/GzltbaUYkq92PmNnqIxm0sBSUxqXdWFeoAgkRCjrtHOcs480d8p5ETYL0Lyx7fBtOHMw==",
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.49.0.tgz",
+      "integrity": "sha512-0KVKivo1xrjXJpsQ6MmEV9bFAOOxELPgW77hC1b9V9EYdNxnNYSIuXcENMscsM77NW/PAanrEUOkBiWhR9E2jw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7935,12 +7975,12 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.1.tgz",
-      "integrity": "sha512-ZfJSCxWr4Ss5qGja9W7L6+8vcrbX0n+tKDe2TrYvTq6GiqEc+0MrajIl4vi/58jhceHbSze1ITX/ocC3Ed3NLg==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.49.0.tgz",
+      "integrity": "sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.48.1"
+        "@wordpress/hooks": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7948,12 +7988,12 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.48.1.tgz",
-      "integrity": "sha512-UmouS3KAAUf6q90adAM37FZ3Tq+w+5UfNVUEKRtZjzbH3gMZJTKmYXpG9dkYyLLmicXgOrcG1GQ0qTX91MjAuA==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.49.0.tgz",
+      "integrity": "sha512-ysZvqyw1PvClTWqVwLzsE7cqfYU+QppJwu2Ji/rUGyFL9WSNdMIgIQhJWZMBiw0gBtD/uuiQe7OoVJfEGw0JYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.48.1"
+        "@wordpress/deprecated": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7961,9 +8001,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.48.1.tgz",
-      "integrity": "sha512-EYd2H8cYSk8H3wSnTK1wTtuC+hOCmMmZrCEBWzgHevs1n3B9g0nwBafSiRWpzc0vA2vculkNNtlSfy3ByJ2hag==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.49.0.tgz",
+      "integrity": "sha512-faTCKkv9zjxKKq5RNmA20piRog14+KgAy7/Pw1hbxB1JCsimxFr7f+Vg268TIFbWQJiqX1S+YuKySFGQ/hpk8Q==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7971,56 +8011,55 @@
       }
     },
     "node_modules/@wordpress/editor": {
-      "version": "14.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.48.1.tgz",
-      "integrity": "sha512-K64jYbJxIKw+xonGEqqyTPM9ZRHrDuI1tyZnw8y6PQu999wd4RtniMJGyUXgS5R582liLmlUam7Ai6Bk4NP7KQ==",
+      "version": "14.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.49.0.tgz",
+      "integrity": "sha512-vfEPx4fliGOInWMtZKArbiIQW6Telj5kZf1pNN8/ZIft2KDQsLoP5L7Wt31SCJkrY64YdHYm5EdWl4dVhfUp9g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/blob": "^4.48.1",
-        "@wordpress/block-editor": "^15.21.1",
-        "@wordpress/block-serialization-default-parser": "^5.48.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/commands": "^1.48.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/dom": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/fields": "^0.40.1",
-        "@wordpress/global-styles-engine": "^1.15.1",
-        "@wordpress/global-styles-ui": "^1.15.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/interface": "^9.33.1",
-        "@wordpress/keyboard-shortcuts": "^5.48.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/media-editor": "^0.11.1",
-        "@wordpress/media-fields": "^0.13.1",
-        "@wordpress/media-utils": "^5.48.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/patterns": "^2.48.1",
-        "@wordpress/plugins": "^7.48.1",
-        "@wordpress/preferences": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/reusable-blocks": "^5.48.1",
-        "@wordpress/rich-text": "^7.48.1",
-        "@wordpress/server-side-render": "^6.24.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/upload-media": "^0.33.1",
-        "@wordpress/url": "^4.48.1",
-        "@wordpress/views": "^1.15.1",
-        "@wordpress/warning": "^3.48.1",
-        "@wordpress/wordcount": "^4.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/blob": "^4.49.0",
+        "@wordpress/block-editor": "^15.22.0",
+        "@wordpress/block-serialization-default-parser": "^5.49.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/commands": "^1.49.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/dom": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/fields": "^0.41.0",
+        "@wordpress/global-styles-engine": "^1.16.0",
+        "@wordpress/global-styles-ui": "^1.16.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/interface": "^9.34.0",
+        "@wordpress/keyboard-shortcuts": "^5.49.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/media-editor": "^0.12.0",
+        "@wordpress/media-fields": "^0.14.0",
+        "@wordpress/media-utils": "^5.49.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/patterns": "^2.49.0",
+        "@wordpress/plugins": "^7.49.0",
+        "@wordpress/preferences": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/reusable-blocks": "^5.49.0",
+        "@wordpress/rich-text": "^7.49.0",
+        "@wordpress/server-side-render": "^6.25.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/upload-media": "^0.34.0",
+        "@wordpress/url": "^4.49.0",
+        "@wordpress/views": "^1.16.0",
+        "@wordpress/warning": "^3.49.0",
+        "@wordpress/wordcount": "^4.49.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
@@ -8030,6 +8069,7 @@
         "fast-deep-equal": "^3.1.3",
         "memize": "^2.1.0",
         "react-autosize-textarea": "^7.1.0",
+        "redux": "^5.0.1",
         "remove-accents": "^0.5.0",
         "uuid": "^14.0.0"
       },
@@ -8038,20 +8078,26 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-      "integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/escape-html": "^3.48.1",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/escape-html": "^3.49.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.1",
@@ -8063,9 +8109,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.48.1.tgz",
-      "integrity": "sha512-TQJK6sBcmMA5+xMjiAFuivcZ27wUgAfVCgB/fGf7YoxVC+BnCCIanAsHgpY0d4juGUK6LXzDEhU6ZgOpGkGqIQ==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.49.0.tgz",
+      "integrity": "sha512-eOSPRJhmocfi/hztIlbCXbksg54VWIvrbfRbS7AsHY8BelbMyP4YUGEXCZf2jqf5beMB/jqulcsNLsYJ/wC+yw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8073,18 +8119,18 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "25.4.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.4.1.tgz",
-      "integrity": "sha512-snPU3xZ8U72+xwDobRx3cjjidb/BJH6i2LcY5zVs+n8FFksOTBkMvpr7tda78Eb/DfXAxVlanUbDkTs3PSl8Mg==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.5.0.tgz",
+      "integrity": "sha512-9WLjTw/gLqiXTKeYqyOFUrEUPlDm+CS494a992BCqawNmpJn9T1rzUBTSk62nLnqqQhShKq6ryyHkLldkcxcQA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "^7.28.6",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.0",
         "@eslint/compat": "^2.0.0",
-        "@wordpress/babel-preset-default": "^8.48.1",
-        "@wordpress/prettier-config": "^4.48.1",
-        "@wordpress/theme": "^0.15.1",
+        "@wordpress/babel-preset-default": "^8.49.0",
+        "@wordpress/prettier-config": "^4.49.0",
+        "@wordpress/theme": "^0.16.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -8147,38 +8193,37 @@
       }
     },
     "node_modules/@wordpress/fields": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.40.1.tgz",
-      "integrity": "sha512-G/wKSwZYvq5vjFz+UjVAssJv+jwsI5xe6kjMR2cAF2dRPTQyemxgMGRNsKESn3Qy/9R7dsvvIFPeVRX1r+rziQ==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.41.0.tgz",
+      "integrity": "sha512-79pwALynzheV1sKy18PPJPdltSuweZ+IAR7OQT7PJZ/wmzqrheFktLt/2QMpxduoIlcQAw93MuRUdymAGHe2Eg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@types/react": "^18.3.27",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/blob": "^4.48.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/media-utils": "^5.48.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/patterns": "^2.48.1",
-        "@wordpress/primitives": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/router": "^1.48.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/url": "^4.48.1",
-        "@wordpress/warning": "^3.48.1",
-        "@wordpress/wordcount": "^4.48.1",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/blob": "^4.49.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/media-utils": "^5.49.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/patterns": "^2.49.0",
+        "@wordpress/primitives": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/router": "^1.49.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/url": "^4.49.0",
+        "@wordpress/warning": "^3.49.0",
+        "@wordpress/wordcount": "^4.49.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
@@ -8189,19 +8234,25 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.15.1.tgz",
-      "integrity": "sha512-jpMnDkAE1stcoSV19hyet0b2wySMz1kaplNivruKwUyQilkQRIhqlJFiEKBVt513m9I9CbEPA0WKcTpfqJxIMA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.16.0.tgz",
+      "integrity": "sha512-fopMEmf/nwwe2JFlnk2t158bBHAPUnmXEctCFdQyUboi2Zb7VuY+bam4YQ9hhuP4wRhJHWPCyt+ZOrHgST1OBA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/style-engine": "^2.48.1",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/style-engine": "^2.49.0",
         "colord": "^2.9.3",
         "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
@@ -8214,29 +8265,28 @@
       }
     },
     "node_modules/@wordpress/global-styles-ui": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.15.1.tgz",
-      "integrity": "sha512-XscLNs4RT4+MC7pZBX0iwyXN1MMHb0dpLj3TzQKs6vacacWoz4A62u6drOT+lqlTn0u3X7etYaRmCZIE6ec1bg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.16.0.tgz",
+      "integrity": "sha512-qQldhLtUyRuQqJGwEQenLen7zUCjWrl6MifvaMU0P5FcQJBbZlTeYWDzPRDL54ZWjMlRUOcGnhyzWPZkhl4Gmw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/block-editor": "^15.21.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/global-styles-engine": "^1.15.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/ui": "^0.15.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/block-editor": "^15.22.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/global-styles-engine": "^1.16.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/ui": "^0.16.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.9.3"
@@ -8246,14 +8296,20 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.1.tgz",
-      "integrity": "sha512-QZh3Cv9TMJkrCQikuZSsDKTgX+6BBzYJe0MFKp7yP8drj/dtRpkqo5+eYmovBq3pk+HoyP7UJ1vTOb3GPJeU6Q==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
+      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8261,9 +8317,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.48.1.tgz",
-      "integrity": "sha512-Gq6j3yl+m0pc0989jFjAgYbtdwHyUS/5PR39zg+hQfq1IWiqCwfhFlJAqc8ymwx/gSklrxf9mmyhBwmUPWtMcw==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.49.0.tgz",
+      "integrity": "sha512-/ZYK6CPks3VAGFQZ+h56jOy4LB4CC1ZB1SMVY3eeUPStyH84YSz7nTa2P7gw/4uGJhaITMQCmFl7yGFPQOROtg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8271,13 +8327,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.1.tgz",
-      "integrity": "sha512-qBbDJTRCtMfEzTVtzOa/fZf8XlU/JY3nI4MSdxyRQKduFanbXvzTRqJSSEIpZS4ACJTyUqafZX8zEZIH5CrNHQ==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz",
+      "integrity": "sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.48.1",
+        "@wordpress/hooks": "^4.49.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -8291,14 +8347,13 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-14.0.1.tgz",
-      "integrity": "sha512-Vf3wXrS8JWwozKGQ3vS8WQBwmzZyk0ih3W92kE+xPDK2K5QPrlW4MjbSV8gYbNAHC6NECPSWrEGI3DmbgvAP3w==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
+      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/primitives": "^4.48.1",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/primitives": "^4.49.0",
         "change-case": "^4.1.2"
       },
       "engines": {
@@ -8306,19 +8361,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/image-cropper": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.12.1.tgz",
-      "integrity": "sha512-r7t5fzUGzeCt2Pkkp6lgh/a2UKsgW+okeR7Ldw29snE96JZcjYJHyJfRfqOGFZVxrCcoDe2XaEy+Q6PdL+aJhw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.13.0.tgz",
+      "integrity": "sha512-I0vxBdP6NtstFYYeWVqU7QQUdjauJpSQMdof1Z7FQE7Joj3Z99SxeD0KjavOXvQLYvqXz7sb2sf2DkEGIWJX6Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
         "clsx": "^2.1.1",
         "dequal": "^2.0.3",
         "react-easy-crop": "^5.4.2"
@@ -8328,17 +8388,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.48.1.tgz",
-      "integrity": "sha512-Qc+VoBt2XNoOuVMZwjQtZJ8iQfh7mJsSjPlxzSMyYRHGPa+WqfWO50LY/vyXYPs5s5FoMsb3S64ty/p//1DI2w==",
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.49.0.tgz",
+      "integrity": "sha512-hGgqxXfkSEHFdQ+AnFvnBERlNT7B1+l7yYahRPhBA3jms1JNsB0DZZDSpUq292T5yxfuV6hD5uebFpucS0PsCA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
+        "@preact/signals-core": "^1.7.0",
         "preact": "^10.29.1"
       },
       "engines": {
@@ -8347,24 +8414,24 @@
       }
     },
     "node_modules/@wordpress/interface": {
-      "version": "9.33.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.33.1.tgz",
-      "integrity": "sha512-ZXpdEpzrEtiPPxe2FFIIHL0+12T7CS6Ci8gp3rU0LdpvkGEzGps1lL0+hXuAboZkOUPmtcebRZ4QXmafdHvQbw==",
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.34.0.tgz",
+      "integrity": "sha512-Trb/x0A0qRlFUNeHUF9bsFragzmE9V3wTCXWt5l7FBD3+VZ9SM/kf5/etej/n3fosauMnMsLTAyH7uh/cHhvCA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/admin-ui": "^2.3.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/plugins": "^7.48.1",
-        "@wordpress/preferences": "^4.48.1",
-        "@wordpress/viewport": "^6.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/admin-ui": "^2.4.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/plugins": "^7.49.0",
+        "@wordpress/preferences": "^4.49.0",
+        "@wordpress/viewport": "^6.49.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8377,9 +8444,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.48.1.tgz",
-      "integrity": "sha512-qOn4doqp8Xr5vOdF7kni5BThkMLxFA9fZIUVZo/lzs+/rwV7rwdQQXtq/PXnHcOWDOqHSXBVlUciV7clDE6aeA==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.49.0.tgz",
+      "integrity": "sha512-pKvFYoExyT/A5h0Y5wLYs+8gQRaisJps2YF0jICo/LOfXR+TF8mYLH2txrA8ZCDGS0FPLSPjMxAl9hjUGrELRg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8387,9 +8454,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.48.1.tgz",
-      "integrity": "sha512-yoW7R8f2u/FWqJ+Owf7ZWLXrFgPQx/nTvyQLykODazLuU/a571TOg1pgwt+hUMN+8YwiTPWCulm+V079+hi1Qg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.49.0.tgz",
+      "integrity": "sha512-CaRm4xsTybCh8gfy/nyOa/6ujRePFVnGFcI4Cl0xKY5pw1YpYVQOBEad1a4j+EL/hNqFa1W++xZw2TLOs/zw9w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -8405,13 +8472,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.48.1.tgz",
-      "integrity": "sha512-u+bq7iw/Ts1dM1Vc74eEwTxwZvKsVZPMjSmNQ+Tpiyei9b+WpFROYq7+PYlJrtyxAmPyHx/b4nAJEQ1utzhTGg==",
+      "version": "12.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.49.0.tgz",
+      "integrity": "sha512-yDUkAnY4ztoTL59sRgULaF1sxHGzemrMlS9xo11RRbDx9HYcrybjX/X37ABlGwCzv+AmsolVcRfyfmsAxHeJwQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.48.1",
+        "@wordpress/jest-console": "^8.49.0",
         "babel-jest": "^29.7.0"
       },
       "engines": {
@@ -8424,62 +8491,73 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.48.1.tgz",
-      "integrity": "sha512-HYm/Q52G5UvF4rOleWWJaRvsRjWBOyqhcCdlXXtVAWn7qEq5V2Lm5RSdI4L66EVFqRAHAPsz9ouwwiU98N5NFQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.49.0.tgz",
+      "integrity": "sha512-Md7+yO1CCUMqMD5ChpPoRQ5GJ+DAsXs0eEJIFrQXbU63QsIYwIdylT6+WelfWDeB2cLCodjWg0j1vL1S1kjvEw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/keycodes": "^4.48.1"
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/keycodes": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.1.tgz",
-      "integrity": "sha512-mVNex4sY0APJj69kxFfCmaoJVOaNd9Bu7oNecuXKEAI4sp/jvvn0x+IGwLt1lMrLqC3+bPEo+q+JV3KNXMOJIQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz",
+      "integrity": "sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/i18n": "^6.21.1"
+        "@wordpress/i18n": "^6.22.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.3.27"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/media-editor": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.11.1.tgz",
-      "integrity": "sha512-lE1dEzfE9G/BQS9/ZL8GTLf4wSrA6nJ/8TrdU8DFZM+BepCHBkCk9A6MF8qNXNviGSYn4bpUISrYms/SoETjVw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.12.0.tgz",
+      "integrity": "sha512-oPUS6F38HDRnSS3L8UrVIvR/PL0HFlQMEnTNp3w1Xp8NMxTC0pu3rrcknFz4HcItaY0wOvYNdJcVV7uLcK1GIg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/interface": "^9.33.1",
-        "@wordpress/keyboard-shortcuts": "^5.48.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/ui": "^0.15.1",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/interface": "^9.34.0",
+        "@wordpress/keyboard-shortcuts": "^5.49.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/ui": "^0.16.0",
         "clsx": "^2.1.1",
         "gl-matrix": "^3.4.3"
       },
@@ -8488,29 +8566,34 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/media-fields": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.13.1.tgz",
-      "integrity": "sha512-x40tNNZGof7P6sBbGZvl+AmsuDGGnP55xdO/ImxFyBm0IOnAC5ar8YesX/4lXMQc0Ps78d7zVEFxeal2ktPDRA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.14.0.tgz",
+      "integrity": "sha512-0DrvrRVRLP0k0a9kbTH3sNZSpNDEGAejfAUNPtLSXnYIqxBFFyXDYqOzfHUdOaB9ww25zWjtb9yvbxL72YuWCw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/date": "^5.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/primitives": "^4.48.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/url": "^4.48.1",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/date": "^5.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/primitives": "^4.49.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/url": "^4.49.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8518,31 +8601,36 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/media-utils": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.48.1.tgz",
-      "integrity": "sha512-JCnKcbmikHh3Uv+D9M9kolZOaUp++v0zCouzMGGQT9WOt3ePVayzh72cgm9g9UNnPcZHmVO7Vpfbx93RDZMs9w==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.49.0.tgz",
+      "integrity": "sha512-agHN7dLXHnMkFFXQSpspYgxj8cTZ8zBPmGQmsk9aLyq+528HapCYXDhgtVuqgH80r6cl/dSCMm4wM7GocFgwAQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/blob": "^4.48.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/media-fields": "^0.13.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/ui": "^0.15.1",
-        "@wordpress/views": "^1.15.1",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/blob": "^4.49.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/media-fields": "^0.14.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/views": "^1.16.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8550,19 +8638,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.48.1.tgz",
-      "integrity": "sha512-igkUhvyvp+C61HcE7OBiCPkPYMae8k0BQBZblepXghkX82zlqVe5NiueepWTwY7pFDDEsZlxl9sYF2DWf6HF3w==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.49.0.tgz",
+      "integrity": "sha512-Jwk6xudutgVC5ZPGMo4lzg+SMl+XNI05NigagqIV86bkzoLqtqyfJoDS5n1ncr17Ock++KFS5lHvrzXOvsmXLQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/data": "^10.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/data": "^10.49.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8570,13 +8663,19 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.48.1.tgz",
-      "integrity": "sha512-+zEF+kA79DjFLvu7icD51tHHQl/84Bjco8Dm1UlfMhvMxY9JclvwAVcR4PXhl6Ej5j0fRFlbwPI/isU7OFAehQ==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.49.0.tgz",
+      "integrity": "sha512-1Fshw6Fym+4ocePqRyvRhFI5zpw6n4FU+3MiQ9F6kVibbuhpssDAlO/wC6saRY9gl1xjTilLJSVj14WvF+ZeVA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -8588,26 +8687,27 @@
       }
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.48.1.tgz",
-      "integrity": "sha512-/Y3CgMXqGLMOBgDUeWpWm9DtK3Z3Thdwn3i83q6NLaHLx8Ihbqlva78qotrkXH3Bigj45qFC1QwYLpKneZDwKQ==",
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.49.0.tgz",
+      "integrity": "sha512-R57FvRdCUPna0lnRUAi5Ll73DOs1r0orIdnVJGsGcD5vykb48IXcH/IljWZKkIf714BlRyMKiS69JZIAQEdQQw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/block-editor": "^15.21.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/html-entities": "^4.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/url": "^4.48.1"
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/block-editor": "^15.22.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/html-entities": "^4.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/ui": "^0.16.0",
+        "@wordpress/url": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8619,39 +8719,45 @@
       }
     },
     "node_modules/@wordpress/plugins": {
-      "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.48.1.tgz",
-      "integrity": "sha512-4U/q79mG8D65/x/uktv60X2NjbkLZcMo0OErZujfMKbjni2ugbjhEpuV/lF3mVhWoKX8c1nhgEEH7SNdQnRA5Q==",
+      "version": "7.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.49.0.tgz",
+      "integrity": "sha512-029jVpo0N9utfORjajtVcm6DA3Qpc0j4KUXAsb9QZ67ciIwHFZQqwkqMSM3kWPknH88vY5vp4/eXAvWMhLX1Vg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/is-shallow-equal": "^5.48.1",
-        "memize": "^2.1.0"
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/is-shallow-equal": "^5.49.0",
+        "memize": "^2.1.0",
+        "react-is": "^18.3.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.48.1.tgz",
-      "integrity": "sha512-mTSXRTaUhbawT9w3UkVAWQ0NINKGIR0YrUDthNVAe12Jd1DJic9ixqeBDNSwgR9sxiZpTpMWWwcFeXNxD/dT2Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.49.0.tgz",
+      "integrity": "sha512-K117Ge7DVVkm89EAITbP0LgSI3wZluThwET4/E4+/pX5AtYvj9jFmXpOAr+tiBt4qvHcCL6RRBUcRSoVP5W5Lg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/browserslist-config": "^6.48.1",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/browserslist-config": "^6.49.0",
         "autoprefixer": "^10.4.21",
         "postcss-import": "^16.1.1"
       },
@@ -8664,22 +8770,21 @@
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.48.1.tgz",
-      "integrity": "sha512-ETRFHFXRJ80UYXwjy5FQlAHlVZQjC3PUqvrW6KT8aJT/nsy8+uMLV0FUE1e37QqeAwdwMDj9jC/MNz0m3eRmOw==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.49.0.tgz",
+      "integrity": "sha512-EGyLxOD3bCZgm1zqNKLQu3u9XN7iVfZbwTDTVB74eHx3pQEismQrdODnObLmc5Uw4T+XYUUYBoRwnJSOzKSRpQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/private-apis": "^1.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/private-apis": "^1.49.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8687,14 +8792,20 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.48.1.tgz",
-      "integrity": "sha512-7tZfyBAx/ESV8KpwXY/XKghRlSrDPDuyB6XIuuKPjw6cCtPiLnFHFBxNDdyDmwKY0UAWO7834IypSHlPiwffaw==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.49.0.tgz",
+      "integrity": "sha512-yP4hm2m2Hxv3I7HI5lxbrCmh95Db4QWcGJGLq/fysepbLjTnqnMIHRs5p0/QoRMV/MhwFi8vMkNmmQYJt386ug==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -8706,13 +8817,12 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.1.tgz",
-      "integrity": "sha512-nzAcsXhBxw9x2q/ImVa45Ft80TO+e/WgCDmWaU3Zb2trogwThxZTezkE0oeQ6PSxSeGYM6nBgk+qqFCG8wyMhQ==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz",
+      "integrity": "sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/element": "^8.0.1",
+        "@wordpress/element": "^8.1.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8720,13 +8830,19 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.48.1.tgz",
-      "integrity": "sha512-6nPO/FU1f9r9Zilaz7TOFSTIH5ojPqk/mmDFofo0h2kIljqik/mLwBOIls6WdDrQ2kti+BRNohbjGElAcws7kg==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.49.0.tgz",
+      "integrity": "sha512-UcVHYan6qYvDNTFEwEnPBU9I1SnImLjEh54ISgqvvndc7jfxtdi+Akwj2kgxeLRY+bsXzMQr6byD/x4dw56yqA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -8737,9 +8853,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.48.1.tgz",
-      "integrity": "sha512-KddQQq+qboNnc4fROsy9bsX4JENRfvBMtuBg5CjOq11hScFyh169ozoHozMEtNGXou4XFykEHCRwzM5MfSHjiA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.49.0.tgz",
+      "integrity": "sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8747,9 +8863,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.1.tgz",
-      "integrity": "sha512-+mUHB2DxfqGODfc9Lwdhz8D7jjojjWqhoa8w0ckUCzh84ZERiR3BcoiGhCkiWVSl9XedKu9itLFna5Q4gilEZw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.49.0.tgz",
+      "integrity": "sha512-pisFM/iQv23hmrBkWwlQZoMtqR3wXWoaAAf9d++laxlPRkFNfe/AG7gUK9tljhk5k6lP9pdeet4t+qSeQPDxpg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8765,23 +8881,23 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.48.1.tgz",
-      "integrity": "sha512-7QVnJlm4u8goWh/0uvmvkb96gBAG6K33WTWluWFTuBmROB3bOc7Ei2PH9brqQms+cu0HkzCQzpL0oytTpFNf2g==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.49.0.tgz",
+      "integrity": "sha512-Wo22Lib8TYN3hsL0izfJDa53wSCiYouR2kdpCWwcMcGC0JHzc9xCC+MpUzHDVdmKhLVW/FIFtI1N9vjnDtPyPA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.0.1",
-        "@wordpress/block-editor": "^15.21.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/notices": "^5.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/url": "^4.48.1"
+        "@wordpress/base-styles": "^10.1.0",
+        "@wordpress/block-editor": "^15.22.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/notices": "^5.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/url": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8793,22 +8909,21 @@
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.48.1.tgz",
-      "integrity": "sha512-pj+S2d2p4EUJ03V/tOhlvb9qGPixft7v1zj9KEyM70VY6nHD5mmVp95Q5ALtlioyDFWYhzSo609PEd9fJ8FTsQ==",
+      "version": "7.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.49.0.tgz",
+      "integrity": "sha512-RDH3dAnPTimIXYEdJ5+20KyJgmCeEDouA4Hi1Jhl1fiAzjjH1lNcwgs9eNQzaagqQTLfvvWOPX62rkFJnSvvvw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/dom": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/escape-html": "^3.48.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/dom": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/escape-html": "^3.49.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
         "colord": "^2.9.3",
         "memize": "^2.1.0"
       },
@@ -8817,18 +8932,24 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/route": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.14.1.tgz",
-      "integrity": "sha512-hJjvydtzSCyDGn822zsd5vxuyUqribJAWLEOb3wZGtp1H2X+OuN1MVrR4FUexlrr7tz8S8MqryBxGt0dj9L4Yg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.15.0.tgz",
+      "integrity": "sha512-lkktJdVVWsXZACrplhRjUoOMHKV0lq7tIWxERAA8nr8BmPMNG8HGKVJ+mXi82n2TI0/nfFXV0p8g7DcX59+pbw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tanstack/history": "^1.133.28",
         "@tanstack/react-router": "^1.120.5",
-        "@wordpress/private-apis": "^1.48.1"
+        "@wordpress/private-apis": "^1.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8839,16 +8960,15 @@
       }
     },
     "node_modules/@wordpress/router": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.48.1.tgz",
-      "integrity": "sha512-HjN4zJHV6/UZhgEqmWyrAAQkyIV7r61WJUGvuuqL1Yx3fZ9V14Tk4sSjiW6rjhZ2Xyd/RM6mvWSu3d5LXtawuQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.49.0.tgz",
+      "integrity": "sha512-Ihs3B+xyWfAGR1IHEsw2bIPD2wgqs/R+2Uwlq+D0069goUEULBRj6ooSJgs2FsbR1lEyjtK1KLBgZE9TOXhRIg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/url": "^4.48.1",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/url": "^4.49.0",
         "history": "^5.3.0",
         "route-recognizer": "^0.3.4"
       },
@@ -8857,29 +8977,35 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "32.4.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.4.1.tgz",
-      "integrity": "sha512-kcR0zvXUm9qgeHbXVUXlq0M6NaPHMmZ1RudRt7HyS+9I+YK5nomvVgyFzcF/ViO+gbWU8o02iyf6iluihKtloQ==",
+      "version": "32.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.5.0.tgz",
+      "integrity": "sha512-fZysm4M+kNsm7X2jMtW4hKKdnNOvy92rLoMh6TLkHiuDEsTSLHhu6RT/tvTtqvtQ2NOiOBAHA/eF0bVfkWQCbw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "^7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.48.1",
-        "@wordpress/browserslist-config": "^6.48.1",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.48.1",
-        "@wordpress/e2e-test-utils-playwright": "^1.48.1",
-        "@wordpress/eslint-plugin": "^25.4.1",
-        "@wordpress/jest-preset-default": "^12.48.1",
-        "@wordpress/npm-package-json-lint-config": "^5.48.1",
-        "@wordpress/postcss-plugins-preset": "^5.48.1",
-        "@wordpress/prettier-config": "^4.48.1",
-        "@wordpress/stylelint-config": "^23.40.1",
+        "@wordpress/babel-preset-default": "^8.49.0",
+        "@wordpress/browserslist-config": "^6.49.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.49.0",
+        "@wordpress/e2e-test-utils-playwright": "^1.49.0",
+        "@wordpress/eslint-plugin": "^25.5.0",
+        "@wordpress/jest-preset-default": "^12.49.0",
+        "@wordpress/npm-package-json-lint-config": "^5.49.0",
+        "@wordpress/postcss-plugins-preset": "^5.49.0",
+        "@wordpress/prettier-config": "^4.49.0",
+        "@wordpress/stylelint-config": "^23.41.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.2.1",
@@ -9010,9 +9136,9 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.48.1.tgz",
-      "integrity": "sha512-jaBTZHZ0SG1MQ/Nb4GdaH7DMcieFp/ysYOoCodmhfoScFoWTI66/e8egPxU8cOs06gXnOYNPvJ9hnCaeCTz3ug==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.49.0.tgz",
+      "integrity": "sha512-xuhny4GqmKBVVfrPzeJ/d+oa+v71184B9jSeZBE9dsXl4Cp61GIM0TLNwc24p8sO2vhv+eleRQMmRvMLfOCroA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -9252,35 +9378,40 @@
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.24.1.tgz",
-      "integrity": "sha512-ZlmtAdJQ3QEmNlvbpfdD0f0mq/eesSMziqKYvmnjS3eS6t12/S7a7fIiOpKxvRzHzgtRi/f+8u4f+IEoPJm8hA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.25.0.tgz",
+      "integrity": "sha512-me6c6LwF721F534z7n/nBbnjIIRM/iPddMMdjnVH6AhM1lpCK46uCmehq9vA5HTMyyyKFsAOXGCcFOT1uCz54Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/deprecated": "^4.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/url": "^4.48.1"
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/url": "^4.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.48.1.tgz",
-      "integrity": "sha512-zfOz45verEOIf3YIE4zOlMcQoZ2za+OFuJ4SKE+nmglUFLmF2I0iLGlNQO0BNLPI26+krSVZ8kclzJRaB5Z6Kw==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.49.0.tgz",
+      "integrity": "sha512-RG+uTFRjbBxdFNy6S6AEnafC6LeFfcxombbPf+F++/DidCwNw3xUe1TYl5jkda7j2ywTGwopk0VC2vtqG2ZXwQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "memize": "^2.1.0"
@@ -9291,23 +9422,30 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.48.1.tgz",
-      "integrity": "sha512-biMD3eTjoUj5hlmA261kLAlgCN/bjxeeRe7XFrjG/bxQErmYp+hmMSejNTuLpg3j8I11eQ3Vo0iRCjGzn4xFEQ==",
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.49.0.tgz",
+      "integrity": "sha512-U3T2Ss3UtTqBnd6UpFRhDCQyB4XDG1HJbR5tWDx6UjbjgadeAX5+8WqnZumeWd5H/ZRax1WFLs8eqKvRUZA2mA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
         "change-case": "^4.1.2"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.3.27"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/style-runtime": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.4.1.tgz",
-      "integrity": "sha512-guZ0p9a5ZQyyCFPwVqDkhDNVXdXAhIqNkPGSNIGguEtt3OtSOskEMwYJHyXZYX8nlbH0FyKflGJhE4G6QlIWlw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
+      "integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -9315,14 +9453,14 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.40.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.40.1.tgz",
-      "integrity": "sha512-9VaPT7bgMBN/oSRq+HUD3c3muCpZ7Axi4lOShwOhYql9ZVuWkovi94LjJqpXfNvwO0bFUqmfQjZReLa8mlNTuw==",
+      "version": "23.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.41.0.tgz",
+      "integrity": "sha512-IQLjQWY+jRkY/Qke/cRtteXmgNCz77+En5dRW1057zjIvjNU9ZEUywJLkS8vpP9EAxojs2Qn5QtyQ/euuTSLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stylistic/stylelint-plugin": "^3.0.1",
-        "@wordpress/theme": "^0.15.1",
+        "@wordpress/theme": "^0.16.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-recommended-scss": "^14.1.0"
       },
@@ -9336,15 +9474,15 @@
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.48.1.tgz",
-      "integrity": "sha512-RLPTX9f7KdGPyzYDyxwMdnPTEqcAskjOt6AVEb/XJ0gzBmbtqxnoQVrBk/cVcKjaIPTAg2lJkM82RnvnopmoQw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.49.0.tgz",
+      "integrity": "sha512-qjMcjVNk4Zzr6LYEvoNBmZU/ja9jSLPOUhVwIls818LJr7lLs2mMf47gpqFpYv7M0GIDl63zRbQHUFuEPmJHfA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/hooks": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/undo-manager": "^1.48.1",
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/undo-manager": "^1.49.0",
         "diff": "^8.0.3",
         "fast-deep-equal": "^3.1.3",
         "lib0": "^0.2.99",
@@ -9357,15 +9495,14 @@
       }
     },
     "node_modules/@wordpress/theme": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.15.1.tgz",
-      "integrity": "sha512-0SqH40Sd4pKH8YkDjQ4JM2NJzdhliO19QTPHAOAGA+tXuh+YwHOwFxX8Mg0v/vvI4XJD11zuiKGr+grBI7icTQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
+      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/style-runtime": "^0.4.1",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/style-runtime": "^0.5.0",
         "colorjs.io": "^0.6.0",
         "memize": "^2.1.0"
       },
@@ -9374,20 +9511,36 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
+        "esbuild": "^0.27.2",
+        "postcss": "^8.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2"
+        "stylelint": "^16.8.2",
+        "vite": "^7.3.2"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
         "stylelint": {
+          "optional": true
+        },
+        "vite": {
           "optional": true
         }
       }
     },
     "node_modules/@wordpress/token-list": {
-      "version": "3.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.48.1.tgz",
-      "integrity": "sha512-hFAqE8xmTpq/4IVs3AHXxVA2FTrQ2BcOQHsdXJ9kELfcazTZWZsPU2hampfIGYZzyzLnTX06dUubuuy2++LUSQ==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.49.0.tgz",
+      "integrity": "sha512-J1wgnWSEcQQcEOI0TJv1orP1eGa5nuo85hqhIptuQBYEU3vRqCTOn6z73xIJ5R0tWi+8pkedJQxl170zJ/Aifg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9395,23 +9548,21 @@
       }
     },
     "node_modules/@wordpress/ui": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.1.tgz",
-      "integrity": "sha512-zFErzf84zc7dGXrCa9fPKUpMhYx86B8n5GeshC7Ut/nfE7yp09g/Bono5S7KhY1OJx7Z1Jur9t+4vnv5cocBbA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
+      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
-        "@types/react": "^18.3.27",
-        "@wordpress/a11y": "^4.48.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/keycodes": "^4.48.1",
-        "@wordpress/primitives": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/style-runtime": "^0.4.1",
-        "@wordpress/theme": "^0.15.1",
+        "@wordpress/a11y": "^4.49.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/keycodes": "^4.49.0",
+        "@wordpress/primitives": "^4.49.0",
+        "@wordpress/style-runtime": "^0.5.0",
+        "@wordpress/theme": "^0.16.0",
         "clsx": "^2.1.1",
         "tabbable": "^6.4.0"
       },
@@ -9420,17 +9571,23 @@
         "npm": ">=10.2.3"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.48.1.tgz",
-      "integrity": "sha512-i/yHiUQ5S47yong7FXxIRpJgO1MbItEKfcyp1a3rRe66rw1RVPmAlJxyeKaQg9eZbCXOmmDz5cLzZNPyUDN6uA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz",
+      "integrity": "sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.48.1"
+        "@wordpress/is-shallow-equal": "^5.49.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9438,21 +9595,20 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.33.1.tgz",
-      "integrity": "sha512-FjHJGZh7tjUyMbHXiPPHT8oRpM24ENwCOYG7OEoWRGP3NSU5v9Ff4TCksI25Ws420TkrNCFnHlU+xmALQAu30w==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.34.0.tgz",
+      "integrity": "sha512-kUTpZQo+29cbEnxc2S5cKCnxaKkeLlkMqmxPAfvmVgKc+hJF2F00ChEJyd9P5ksLk/+woEtuYOKNr7ohqfob7g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/blob": "^4.48.1",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/preferences": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
-        "@wordpress/url": "^4.48.1",
-        "@wordpress/vips": "^2.1.1",
+        "@wordpress/blob": "^4.49.0",
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/preferences": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/url": "^4.49.0",
+        "@wordpress/vips": "^2.2.0",
         "uuid": "^14.0.0"
       },
       "engines": {
@@ -9460,14 +9616,20 @@
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.48.1.tgz",
-      "integrity": "sha512-EiTMmEwotXY4Cu6casJ10HEe0ocsdVujkm1iZyA0vvu2qtR5IIQqlSVGxDx96cJBP6cB2b8x2ebGLWfnwow4/Q==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.49.0.tgz",
+      "integrity": "sha512-u9Mbph1qh3ZUm2p1HC267frFA1Eg4edC9tagfACxU79p77SKp3loiwfRPM64i50xna8S0wfPwBr0oLF00NawvQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "remove-accents": "^0.5.0"
@@ -9478,36 +9640,41 @@
       }
     },
     "node_modules/@wordpress/viewport": {
-      "version": "6.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.48.1.tgz",
-      "integrity": "sha512-W/bpuh4ndoNUdH2Cfuq2N+vBWU5mSyPdG5bQOaHeK31c2YQfti/3sQTbGZ9h+wHCoUGfI1az87kimPMbqr9GqQ==",
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.49.0.tgz",
+      "integrity": "sha512-JZibnYTgB7oYdp4CKmmb8ovhRmw9qFTBLI7FuGv0QZ0NUh5k2mDKVzP29VcnDb16f/CNMeJU60ZuCQq7/rcr+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.3.27",
-        "@wordpress/compose": "^8.1.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/element": "^8.0.1"
+        "@wordpress/compose": "^8.2.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/element": "^8.1.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {
+        "@types/react": "^18.3.27",
         "react": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/views": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/views/-/views-1.15.1.tgz",
-      "integrity": "sha512-vEcmyVd6UvfLVZWTMtdNGtABGz9CK04muVeoiUvQeHddp+IY6k+kczzBOFX6FOWIo2+xHicjxdIhJH3jlakcCA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/views/-/views-1.16.0.tgz",
+      "integrity": "sha512-TrEcZjISoQfym4GV0p4Amg8sv36kQNPz89xlKeVpFfwt2K6gB60wj5z5Us4CgsjndUDSF3bqY/zSy42vb3l1TA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/core-data": "^7.48.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/dataviews": "^16.0.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/preferences": "^4.48.1",
-        "@wordpress/private-apis": "^1.48.1",
+        "@wordpress/core-data": "^7.49.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/dataviews": "^17.0.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/preferences": "^4.49.0",
+        "@wordpress/private-apis": "^1.49.0",
         "dequal": "^2.0.3"
       },
       "engines": {
@@ -9516,13 +9683,13 @@
       }
     },
     "node_modules/@wordpress/vips": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.1.1.tgz",
-      "integrity": "sha512-3NvM0Bk4xrNhYI8Xgn9+dphE3FbJANhe9aNoU1J/Wqmqt3EpUJY5KoykFkfpHJWbdiLohSMkKIyVylGMdHpP7g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.2.0.tgz",
+      "integrity": "sha512-3GC+P/SC5/tqshTUe1vAARVpL/sCQU3Qvn6nmECfEldJY5ViBUM+yW0jcqNVkcMCd6WQsjSHcwozgx6BjtHCqg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/worker-threads": "^1.8.1",
-        "wasm-vips": "^0.0.17"
+        "@wordpress/worker-threads": "^1.9.0",
+        "wasm-vips": "^0.0.18"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9530,9 +9697,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.1.tgz",
-      "integrity": "sha512-5YyMCOHycuHG+AjsVEUafpTqV4b4qjVv/tel5m1L8k8g8dUW5T/XKguFo1nhCqQc4HqoGBrJtKjaf6dMmg8uWg==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.49.0.tgz",
+      "integrity": "sha512-00KmZy5kT8vm48HKNQxsgiq3GXdgaPGClneMFTe9EWjop9Ghyq8MaYIqjYY75eOgPTFVcKKQyXK9/DAAQxsQuA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9540,9 +9707,9 @@
       }
     },
     "node_modules/@wordpress/wordcount": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.48.1.tgz",
-      "integrity": "sha512-/IdYqxbvAFgAf3O72lUj5ybeWMglG2dYwL8wz17koSHqH5XKlbIQrNGvz4XIvQueiewd4MvLOqIFt2TVHHU6/A==",
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.49.0.tgz",
+      "integrity": "sha512-4UkZySzJKxnu4t0+t+nxW/j+8pOPbc96dp7/v1SffAdGRABik7V7vEpvL9NN3e1FiZgrbtwdWK2P4zsvJzMg9w==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9550,9 +9717,9 @@
       }
     },
     "node_modules/@wordpress/worker-threads": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.8.1.tgz",
-      "integrity": "sha512-xrVypgVxciFPyc704/0fdQ6bf5BZrf2EXtTPQ4BSU0ylnvfSvgvTCYWdVzlI4VySq+FNfHgLHTCxKiKT23CrSQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.9.0.tgz",
+      "integrity": "sha512-UAOns1u+ZljgJtbv07kSIWzVCUSXCxk5KDSQgw4Sx5MKOHqcuNoF9p8HorE5DiAOgJA01CxxXLs03peTF65X6Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "comctx": "^1.4.3"
@@ -10172,9 +10339,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
       "dev": true,
       "funding": [
         {
@@ -10192,8 +10359,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -10241,9 +10408,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10641,9 +10808,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -10748,9 +10915,9 @@
       "license": "MIT"
     },
     "node_modules/bonjour-service": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.1.tgz",
-      "integrity": "sha512-9KM4QMPKnaJqaja1v7gYO/+TXZGLtzPA05NmUTqDAJjcsWeVoOXKMvU9g0gfuuoYTQqJZ924hivICd5R/bCJbA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.2.tgz",
+      "integrity": "sha512-lMskhnsW70yWHr4PhPeh2rvaIkLSaDpp+nmtbXBZaNKTXwxL73QOkW6HhbzqTImXjevn9TreGT4GACGBCGP9nQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10790,9 +10957,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "funding": [
         {
           "type": "opencollective",
@@ -10809,10 +10976,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -11904,9 +12071,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12882,6 +13049,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13302,9 +13470,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.373",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
-      "integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
+      "version": "1.5.378",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -13367,9 +13535,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+      "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13653,9 +13821,9 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
-      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.3.tgz",
+      "integrity": "sha512-3OJmZ3m4VNhTWEfn/bPv7yoSd/7Kx0MYdm27o7SqgS45l03O4purW3zO4B/4JroAWHluvmQaXqrPXFtT4IKYEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14040,9 +14208,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14099,9 +14267,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright/node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15270,6 +15438,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -15481,13 +15650,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/global-modules": {
       "version": "0.2.3",
@@ -16074,9 +16236,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16206,9 +16368,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.8.tgz",
+      "integrity": "sha512-TM5YqrGeTsVIPPpILzeqZ8D2Zc2TvNgSDi88zPF2a4cyqQdWV/wVWBDRDbNzzrLeRWScrFcOX9lW2iX6GOtUDw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16505,9 +16667,9 @@
       }
     },
     "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -16997,9 +17159,9 @@
       "license": "MIT"
     },
     "node_modules/isbot": {
-      "version": "5.1.43",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.43.tgz",
-      "integrity": "sha512-drJhFmibra4LO6Wd7D3Oi6UICRK9244vSZkmxzhlZP0TTdwCA2ueK4PEkUkzPYeuqug9+cqqdWPgihjk5+83Cg==",
+      "version": "5.1.44",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.44.tgz",
+      "integrity": "sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==",
       "license": "Unlicense",
       "engines": {
         "node": ">=18"
@@ -17903,9 +18065,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -18091,9 +18253,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "version": "18.2.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -18580,9 +18742,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -18676,9 +18838,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
-      "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
+      "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18701,9 +18863,9 @@
       }
     },
     "node_modules/listr2": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
-      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+      "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19032,9 +19194,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -19215,6 +19377,18 @@
       "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/marky": {
       "version": "1.3.0",
@@ -19577,6 +19751,98 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -19688,9 +19954,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -19773,9 +20039,9 @@
       "license": "MIT"
     },
     "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19809,9 +20075,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19834,9 +20100,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -19961,9 +20227,9 @@
       "license": "MIT"
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -20426,6 +20692,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20565,9 +20832,9 @@
       }
     },
     "node_modules/parsel-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.2.tgz",
-      "integrity": "sha512-AVJMlwQ4bL2Y0VvYJGk+Fp7eX4SCH2uFoNApmn4yKWACUewZ+alwW3tyoe1r5Z3aLYQTuAuPZIyGghMfO/Tlxw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.3.tgz",
+      "integrity": "sha512-kJHFmSNnujpusFfVEXjNaoJ09VYHF8Ih0aVUn7Clu+Ug8AFoA2wx7Ezh17JfW4+vhm/lauAd9A+//uFkmydZtQ==",
       "funding": [
         {
           "type": "individual",
@@ -20680,9 +20947,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
-      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -20860,14 +21127,14 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -20880,9 +21147,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -21127,9 +21394,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -21984,13 +22251,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -22580,6 +22848,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22609,12 +22878,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "license": "ISC"
     },
     "node_modules/requireindex": {
       "version": "1.2.0",
@@ -23242,9 +23505,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -23365,12 +23628,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -23490,9 +23747,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23508,225 +23765,6 @@
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/showdown": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
-      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "yargs": "^14.2"
-      },
-      "bin": {
-        "showdown": "bin/showdown.js"
-      }
-    },
-    "node_modules/showdown/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/showdown/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/showdown/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/showdown/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/showdown/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "license": "MIT"
-    },
-    "node_modules/showdown/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/showdown/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/showdown/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/showdown/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/showdown/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/showdown/node_modules/yargs": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^15.0.1"
-      }
-    },
-    "node_modules/showdown/node_modules/yargs-parser": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
-      "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -25143,9 +25181,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/table": {
@@ -25572,19 +25610,19 @@
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.3.tgz",
-      "integrity": "sha512-9XCxITTKwJZ1VP3NmW3jZrtZFbUs9c6MoczqtvQXQddBdlxXF/6BXDe9SvR3TcHg8yYttEqoQmbLibR8R2XIJQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.4.tgz",
+      "integrity": "sha512-dWoPOFTKO8ueaPsSpohPUsd5DWsRREa7P5WdKPVOwoLaNdSLfYatWtJEpS9DXRh/q/4ErhpqUF1Qp79qK1IzFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.3"
+        "tldts-core": "^7.4.4"
       }
     },
     "node_modules/tldts-icann/node_modules/tldts-core": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
-      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -25903,16 +25941,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
-      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1"
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -26246,9 +26284,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -26359,12 +26397,12 @@
       }
     },
     "node_modules/wasm-vips": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.17.tgz",
-      "integrity": "sha512-nhkqUNJDUymImoXGrVfImC4wzIFTb9KfBpAngb7dcEQNPP1gVTx4+WL3VVVDSXQpMsyeacsQDOx0+DM33Rpurg==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.18.tgz",
+      "integrity": "sha512-AJyCvxZj/3qceKNnh+YyEobu/IaJFoPN7x7SxyyHmYBS3kASMqJqxQEuN0ZHKQDWsCJ8armfx4Tq3uKrNc+nMA==",
       "license": "MIT",
       "engines": {
-        "node": ">=16.4.0"
+        "node": ">=17.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -26415,9 +26453,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.107.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+      "version": "5.108.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.0.tgz",
+      "integrity": "sha512-Ln1JuYGPRTXcHECapSFSvACtHmWEN5sQqFJeLLGQ0057S7qzT2eXUz0MZUedtmIrNy3nJgnITSubIYKGED9jSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26430,19 +26468,18 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.0",
+        "enhanced-resolve": "^5.22.2",
         "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.5.0",
-        "watchpack": "^2.5.1",
+        "watchpack": "^2.5.2",
         "webpack-sources": "^3.5.0"
       },
       "bin": {
@@ -26963,12 +27000,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "license": "ISC"
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -27205,9 +27236,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27350,21 +27381,21 @@
       "version": "1.1.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.48.1",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^5.48.1",
-        "@wordpress/block-editor": "^15.21.1",
-        "@wordpress/blocks": "^15.21.1",
-        "@wordpress/components": "^35.0.1",
-        "@wordpress/data": "^10.48.1",
-        "@wordpress/editor": "^14.48.1",
-        "@wordpress/element": "^8.0.1",
-        "@wordpress/i18n": "^6.21.1",
-        "@wordpress/icons": "^14.0.1",
-        "@wordpress/plugins": "^7.48.1",
-        "@wordpress/server-side-render": "^6.24.1"
+        "@wordpress/api-fetch": "^7.49.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^5.49.0",
+        "@wordpress/block-editor": "^15.22.0",
+        "@wordpress/blocks": "^15.22.0",
+        "@wordpress/components": "^36.0.0",
+        "@wordpress/data": "^10.49.0",
+        "@wordpress/editor": "^14.49.0",
+        "@wordpress/element": "^8.1.0",
+        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/icons": "^15.0.0",
+        "@wordpress/plugins": "^7.49.0",
+        "@wordpress/server-side-render": "^6.25.0"
       },
       "devDependencies": {
-        "@wordpress/scripts": "^32.4.1"
+        "@wordpress/scripts": "^32.5.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwtv-underscores",
-  "version": "7.0.8",
+  "version": "7.0.9",
   "description": "LezWatch.TV Custom Theme.",
   "main": "index.js",
   "workspaces": [
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@parcel/watcher": "^2",
     "@types/node": "^22",
-    "@wordpress/scripts": "^32.4.1",
+    "@wordpress/scripts": "^32.5.0",
     "autoprefixer": "^10.4",
     "css-minimizer-webpack-plugin": "^8.0",
     "eslint-plugin-prettier": "^5.5",

--- a/plugins/lwtv-plugin/php/blocks/package.json
+++ b/plugins/lwtv-plugin/php/blocks/package.json
@@ -19,20 +19,20 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
-		"@wordpress/api-fetch": "^7.48.1",
-		"@wordpress/babel-plugin-import-jsx-pragma": "^5.48.1",
-		"@wordpress/block-editor": "^15.21.1",
-		"@wordpress/blocks": "^15.21.1",
-		"@wordpress/components": "^35.0.1",
-		"@wordpress/data": "^10.48.1",
-		"@wordpress/editor": "^14.48.1",
-		"@wordpress/element": "^8.0.1",
-		"@wordpress/i18n": "^6.21.1",
-		"@wordpress/icons": "^14.0.1",
-		"@wordpress/plugins": "^7.48.1",
-		"@wordpress/server-side-render": "^6.24.1"
+		"@wordpress/api-fetch": "^7.49.0",
+		"@wordpress/babel-plugin-import-jsx-pragma": "^5.49.0",
+		"@wordpress/block-editor": "^15.22.0",
+		"@wordpress/blocks": "^15.22.0",
+		"@wordpress/components": "^36.0.0",
+		"@wordpress/data": "^10.49.0",
+		"@wordpress/editor": "^14.49.0",
+		"@wordpress/element": "^8.1.0",
+		"@wordpress/i18n": "^6.22.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/plugins": "^7.49.0",
+		"@wordpress/server-side-render": "^6.25.0"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^32.4.1"
+		"@wordpress/scripts": "^32.5.0"
 	}
 }

--- a/plugins/lwtv-plugin/php/plugins/facetwp/class-indexing.php
+++ b/plugins/lwtv-plugin/php/plugins/facetwp/class-indexing.php
@@ -354,8 +354,9 @@ class Indexing {
 	 * @return array
 	 */
 	public function facetwp_index_row_shows_loved( $params, $facet_class ) {
-		$params['facet_value']         = ( 'on' === $params['facet_value'] ) ? 'yes' : 'no';
-		$params['facet_display_value'] = ( 'on' === $params['facet_display_value'] ) ? 'Yes' : 'No';
+		// ACF true_false stores 1; CMB2/legacy stored 'on'; treat any truthy value as loved.
+		$params['facet_value']         = ( ! empty( $params['facet_value'] ) ) ? 'yes' : 'no';
+		$params['facet_display_value'] = ( 'yes' === $params['facet_value'] ) ? 'Yes' : 'No';
 		$facet_class->insert( $params );
 
 		// skip default indexing

--- a/plugins/lwtv-plugin/php/wp-cli/cli-generate.php
+++ b/plugins/lwtv-plugin/php/wp-cli/cli-generate.php
@@ -245,6 +245,8 @@ class WP_CLI_LWTV_Generate {
 			case 'thu':
 				\WP_CLI::log( 'Debugger: Checking all actors...' );
 				( new Actors_Debugger() )->find_actors_problems();
+				\WP_CLI::log( 'Debugger: Checking actors for iMDB...' );
+				( new Actors_Debugger() )->find_actors_no_imdb();
 				break;
 			case 'fri':
 				\WP_CLI::log( 'Debugger: Checking all characters...' );
@@ -253,12 +255,17 @@ class WP_CLI_LWTV_Generate {
 			case 'sat':
 				\WP_CLI::log( 'Debugger: Checking all shows...' );
 				( new Shows_Debugger() )->find_shows_problems();
-				break;
-			case 'sun':
-				\WP_CLI::log( 'Debugger: Checking actors for iMDB...' );
-				( new Actors_Debugger() )->find_actors_no_imdb();
 				\WP_CLI::log( 'Debugger: Checking shows for iMDB...' );
 				( new Shows_Debugger() )->find_shows_no_imdb();
+				break;
+			case 'sun':
+				\WP_CLI::log( 'Debugger: Force re-indexing FacetWP...' );
+				if ( function_exists( 'FWP' ) ) {
+					FWP()->indexer->index( true );
+					\WP_CLI::log( 'FacetWP re-index complete.' );
+				} else {
+					\WP_CLI::warning( 'FacetWP is not active; skipping reindex.' );
+				}
 				break;
 			default:
 				\WP_CLI::warning( 'You must provide a valid day of the week. Use the THREE letter version (Mon, Tue, etc)' );


### PR DESCRIPTION
This PR bundles the June monthly maintenance pass: WordPress block dependency
bumps, a FacetWP compatibility fix for the ACF `true_false` field type left
over from the CMB2 migration, and a restructured WP-CLI cron debug schedule
that adds a weekly FacetWP force-reindex on Sundays.

### Fixes

- **FacetWP "Shows We Love" indexing:** ACF stores `true_false` as `1`; the
  old check compared against `'on'` (CMB2/legacy), so loved shows were never
  indexed as `yes`. Switch to `!empty()` so any truthy value is treated as
  loved (`class-indexing.php:354`).

### Changes

- **WP-CLI cron schedule (`cli-generate.php`):**
  - Thursday: run actor problems check **and** actor iMDB check together.
  - Saturday: run shows problems check **and** shows iMDB check together.
  - Sunday: force FacetWP full re-index (new); gracefully skips with a warning
    if FacetWP is not active.
- **Ping script:** update `BASEURL` to the new health-check endpoint UUID.

### Dependency bumps

- `@wordpress/scripts` → `^32.5.0`
- All `@wordpress/*` block packages bumped to their latest minor versions
  (e.g., `@wordpress/components` `^35` → `^36`, `@wordpress/icons` `^14` → `^15`).
- Theme version bumped to `7.0.9`.