### PR TITLE
fix: update ACF repeater queries from serialized to sub-field meta keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.10] - 2026-06-26
+
+### Fixed
+
+- Dead character role-type counts (regular/recurring/guest) now return correct results after ACF migrated repeater data from a single serialized meta value to individual sub-field meta rows.
+- Taxonomy statistics pages now correctly count characters and deaths per show.
+- "This Year" character lists now populate for shows airing in the current year.
+- Actor excerpt cards on taxonomy archive pages now render with the correct post context.
+
 ## [7.0.9] - 2026-06-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwtv-underscores",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "description": "LezWatch.TV Custom Theme.",
   "main": "index.js",
   "workspaces": [

--- a/plugins/lwtv-plugin/php/statistics/build/class-dead.php
+++ b/plugins/lwtv-plugin/php/statistics/build/class-dead.php
@@ -814,31 +814,21 @@ class Dead {
 		}
 
 		try {
-			// Query to get all dead characters and their show group meta data
-			$query = $wpdb->prepare(
-				"SELECT
-					p.ID,
-					p.post_title,
-					show_meta.meta_value as show_group_data
-				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-				INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-				LEFT JOIN {$wpdb->postmeta} show_meta ON p.ID = show_meta.post_id AND show_meta.meta_key = %s
-				WHERE p.post_type = %s
-				AND p.post_status = 'publish'
-				AND tt.taxonomy = %s
-				AND t.slug = %s
-				AND show_meta.meta_value IS NOT NULL
-				AND show_meta.meta_value != ''
-				ORDER BY p.post_title ASC",
-				'lezchars_show_group',
-				'post_type_characters',
-				'lez_cliches',
-				'dead'
-			);
+			// ACF repeater fields store sub-fields as separate meta keys (lezchars_show_group_N_type),
+			// not as a serialized value under lezchars_show_group. Query sub-field keys directly.
+			$query = "SELECT pm_type.meta_value as role_type
+				FROM {$wpdb->postmeta} pm_type
+				INNER JOIN {$wpdb->posts} p ON p.ID = pm_type.post_id
+					AND p.post_type = 'post_type_characters'
+					AND p.post_status = 'publish'
+				INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = pm_type.post_id
+				INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+					AND tt.taxonomy = 'lez_cliches'
+				INNER JOIN {$wpdb->terms} t ON t.term_id = tt.term_id
+					AND t.slug = 'dead'
+				WHERE pm_type.meta_key REGEXP 'lezchars_show_group_[0-9]+_type'";
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- This is a prepared query (see above)
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No user input in query
 			$results = $wpdb->get_results( $query, ARRAY_A );
 
 			// Initialize role counters
@@ -848,27 +838,10 @@ class Dead {
 				'guest'     => 0,
 			);
 
-			// Process each character's show group data
 			foreach ( $results as $row ) {
-				$show_group_data = maybe_unserialize( $row['show_group_data'] );
-
-				// Ensure it's an array
-				if ( ! is_array( $show_group_data ) ) {
-					continue;
-				}
-
-				// Process each show entry
-				foreach ( $show_group_data as $show_entry ) {
-					if ( ! is_array( $show_entry ) || ! isset( $show_entry['type'] ) ) {
-						continue;
-					}
-
-					$role_type = $show_entry['type'];
-
-					// Count only valid role types
-					if ( isset( $role_counts[ $role_type ] ) ) {
-						++$role_counts[ $role_type ];
-					}
+				$role_type = $row['role_type'];
+				if ( isset( $role_counts[ $role_type ] ) ) {
+					++$role_counts[ $role_type ];
 				}
 			}
 

--- a/plugins/lwtv-plugin/php/statistics/build/class-taxonomy-optimized.php
+++ b/plugins/lwtv-plugin/php/statistics/build/class-taxonomy-optimized.php
@@ -173,10 +173,8 @@ class Taxonomy_Optimized {
 		$term_placeholders = implode( ',', array_fill( 0, count( $term_slugs ), '%s' ) );
 
 		// Single query to get both total and dead character counts.
-		// Characters are linked to shows through lezchars_show_group meta (serialized array), e.g.:
-		// a:1:{i:0;a:3:{s:4:"show";a:1:{i:0;s:3:"655";}s:4:"type";s:9:"recurring";s:7:"appears";a:1:{i:0;s:4:"2017";}}}
-		// Join postmeta and characters AFTER `shows` so each row ties one show to matching character
-		// meta — never unconstrained LEFT JOIN all published characters (cartesian explosion).
+		// ACF repeater stores show relationships as individual meta keys (lezchars_show_group_N_show),
+		// not as a serialized value under lezchars_show_group. Join on the sub-field key directly.
 		// phpcs:disable
 		$query = $wpdb->prepare(
 			"SELECT
@@ -187,10 +185,8 @@ class Taxonomy_Optimized {
 			INNER JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
 			LEFT JOIN {$wpdb->term_relationships} tr ON tt.term_taxonomy_id = tr.term_taxonomy_id
 			LEFT JOIN {$wpdb->posts} shows ON tr.object_id = shows.ID
-			INNER JOIN {$wpdb->postmeta} char_shows ON char_shows.meta_key = 'lezchars_show_group'
-				AND char_shows.meta_value IS NOT NULL
-				AND char_shows.meta_value != ''
-				AND char_shows.meta_value COLLATE utf8mb4_unicode_ci LIKE CONCAT('%%s:', LENGTH(CAST(shows.ID AS CHAR)), ':\"', CAST(shows.ID AS CHAR), '\";%%') COLLATE utf8mb4_unicode_ci
+			INNER JOIN {$wpdb->postmeta} char_shows ON char_shows.meta_key LIKE 'lezchars_show_group_%_show'
+				AND char_shows.meta_value = shows.ID
 			INNER JOIN {$wpdb->posts} chars ON chars.ID = char_shows.post_id AND chars.post_type = %s AND chars.post_status = 'publish'
 			LEFT JOIN {$wpdb->postmeta} chars_death ON chars.ID = chars_death.post_id AND chars_death.meta_key = 'lezchars_last_death'
 			WHERE tt.taxonomy = %s

--- a/plugins/lwtv-plugin/php/statistics/class-stats-generator.php
+++ b/plugins/lwtv-plugin/php/statistics/class-stats-generator.php
@@ -249,7 +249,6 @@ class Stats_Generator {
 
 		if ( empty( $all_data ) ) {
 			lwtv_plugin()->debug_log( 'statistics', 'All data for dead is empty' );
-			return array();
 		}
 
 		return ( new Stats_Handler() )->handle( $all_data, $context, $view, $format, 'death', array(), $bar_direction );

--- a/plugins/lwtv-plugin/php/this-year/build/class-shows-builder.php
+++ b/plugins/lwtv-plugin/php/this-year/build/class-shows-builder.php
@@ -292,30 +292,45 @@ class Shows_Builder {
 			return array();
 		}
 
+		// Filter out null values that get_show_id_by_slug() may return
+		$show_ids = array_values( array_filter( $show_ids ) );
+		if ( empty( $show_ids ) ) {
+			return array();
+		}
+
 		global $wpdb;
 
-		// Get ALL character show group data (much simpler than trying to match serialized patterns)
-		$query = "SELECT post_id, meta_value
+		// ACF repeater fields store sub-fields as separate meta keys (lezchars_show_group_N_show),
+		// not as a single serialized value under lezchars_show_group. Query sub-field keys to find
+		// which characters are linked to our target shows.
+		$placeholders = implode( ',', array_fill( 0, count( $show_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$query                   = $wpdb->prepare(
+			"SELECT DISTINCT post_id
 			FROM {$wpdb->postmeta}
-			WHERE meta_key = 'lezchars_show_group'
-			AND meta_value IS NOT NULL
-			AND meta_value != ''";
+			WHERE meta_key REGEXP 'lezchars_show_group_[0-9]+_show'
+			AND meta_value IN ($placeholders)",
+			$show_ids
+		);
+		$candidate_character_ids = $wpdb->get_col( $query );
+		// phpcs:enable
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No user input in query
-		$show_group_results = $wpdb->get_results( $query, ARRAY_A );
+		if ( empty( $candidate_character_ids ) ) {
+			return array();
+		}
 
-		// Process show group data and collect characters by show
+		// Process show group data using ACF API (handles repeater sub-field assembly)
 		$characters_by_show = array();
 		$character_ids      = array();
 
-		foreach ( $show_group_results as $row ) {
-			$show_group_data = maybe_unserialize( $row['meta_value'] );
+		foreach ( $candidate_character_ids as $character_id ) {
+			$character_id    = (int) $character_id;
+			$show_group_data = get_field( 'lezchars_show_group', $character_id );
+
 			if ( ! is_array( $show_group_data ) ) {
 				continue;
 			}
-
-			$character_id    = (int) $row['post_id'];
-			$character_ids[] = $character_id;
 
 			foreach ( $show_group_data as $show_relationship ) {
 				if ( ! is_array( $show_relationship ) || ! isset( $show_relationship['show'] ) || ! isset( $show_relationship['type'] ) ) {
@@ -331,28 +346,34 @@ class Shows_Builder {
 				$character_type = $show_relationship['type'];
 
 				// Only process if this show is in our target show IDs
-				if ( in_array( $show_id, $show_ids, true ) ) {
-					// Check if character appeared in this show during the specified year
-					if ( isset( $show_relationship['appears'] ) && is_array( $show_relationship['appears'] ) ) {
-						$appeared_in_year = false;
-						foreach ( $show_relationship['appears'] as $appears_year ) {
-							if ( (int) $appears_year === $year ) {
-								$appeared_in_year = true;
-								break;
-							}
-						}
+				if ( ! in_array( $show_id, $show_ids, true ) ) {
+					continue;
+				}
 
-						if ( $appeared_in_year ) {
-							if ( ! isset( $characters_by_show[ $show_id ] ) ) {
-								$characters_by_show[ $show_id ] = array();
-							}
+				// Check if character appeared in this show during the specified year
+				if ( ! isset( $show_relationship['appears'] ) || ! is_array( $show_relationship['appears'] ) ) {
+					continue;
+				}
 
-							$characters_by_show[ $show_id ][] = array(
-								'character_id' => $character_id,
-								'type'         => $character_type,
-							);
-						}
+				$appeared_in_year = false;
+				foreach ( $show_relationship['appears'] as $appears_year ) {
+					if ( (int) $appears_year === $year ) {
+						$appeared_in_year = true;
+						break;
 					}
+				}
+
+				if ( $appeared_in_year ) {
+					if ( ! isset( $characters_by_show[ $show_id ] ) ) {
+						$characters_by_show[ $show_id ] = array();
+					}
+
+					$characters_by_show[ $show_id ][] = array(
+						'character_id' => $character_id,
+						'type'         => $character_type,
+					);
+
+					$character_ids[] = $character_id;
 				}
 			}
 		}

--- a/taxonomy.php
+++ b/taxonomy.php
@@ -88,7 +88,7 @@ get_header(); ?>
 													get_template_part( 'template-parts/excerpt/shows' );
 													break;
 												case 'post_type_actors':
-													get_template_part( 'template-parts/excerpt/actors' );
+													get_template_part( 'template-parts/excerpt/actors', '', array( 'actor' => get_the_ID() ) );
 													break;
 												default:
 													get_template_part( 'template-parts/content/posts' );


### PR DESCRIPTION
ACF repeater fields no longer store relationship data as a single serialized
value under `lezchars_show_group`. Instead, ACF writes each sub-field as its
own meta row (e.g. `lezchars_show_group_0_show`, `lezchars_show_group_0_type`).
Several statistics and "This Year" queries were still targeting the old
serialized format, returning empty or incorrect results.

### Changes

**Statistics — dead character role counts (`class-dead.php`)**
- Replace prepared query on `lezchars_show_group` serialized value with a
  REGEXP query targeting `lezchars_show_group_N_type` sub-field keys
- Flatten result processing; remove `maybe_unserialize` and nested loop

**Statistics — taxonomy character counts (`class-taxonomy-optimized.php`)**
- Replace LIKE-pattern join on serialized `lezchars_show_group` with a direct
  join on `lezchars_show_group_%_show` sub-field keys matched to `shows.ID`
- Update inline comment to document the ACF sub-field storage model

**Statistics — dead stats generator (`class-stats-generator.php`)**
- Remove early `return array()` on empty `$all_data`; allow `Stats_Handler`
  to handle the empty case consistently

**This Year — shows builder (`class-shows-builder.php`)**
- Filter null values from `$show_ids` before querying
- Replace raw serialized meta fetch with a prepared REGEXP query on
  `lezchars_show_group_N_show` sub-field keys to get candidate character IDs
- Use `get_field( 'lezchars_show_group', $character_id )` (ACF API) to read
  the assembled repeater array per character
- Refactor inner loop to use early-continue pattern; fix `$character_ids[]`
  append placement (was outside the year-match branch)

**Theme — taxonomy template (`taxonomy.php`)**
- Pass `array( 'actor' => get_the_ID() )` when loading the actors excerpt
  template part so the template receives the post ID as context