### PR TITLE
fix(data): improve robustness of date and ACF field handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@parcel/watcher": "^2",
         "@types/node": "^22",
-        "@wordpress/scripts": "^32.5.1",
+        "@wordpress/scripts": "^32.6.0",
         "autoprefixer": "^10.4",
         "css-minimizer-webpack-plugin": "^8.0",
         "eslint-plugin-prettier": "^5.5",
@@ -5964,14 +5964,14 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.170.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.16.tgz",
-      "integrity": "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g==",
+      "version": "1.170.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.17.tgz",
+      "integrity": "sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "@tanstack/react-store": "^0.9.3",
-        "@tanstack/router-core": "1.171.13",
+        "@tanstack/router-core": "1.171.14",
         "isbot": "^5.1.22"
       },
       "engines": {
@@ -6005,9 +6005,9 @@
       }
     },
     "node_modules/@tanstack/router-core": {
-      "version": "1.171.13",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.13.tgz",
-      "integrity": "sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==",
+      "version": "1.171.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.14.tgz",
+      "integrity": "sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.162.0",
@@ -7398,13 +7398,13 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.49.0.tgz",
-      "integrity": "sha512-owb2VJYS54F6R0cjxZzb/Jp+ogGaMpSkuZAWG8VqMW6I8PnFCva+6H4PP3flF7QnaiCvvgEIl2grsSJmUm9O7g==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.50.0.tgz",
+      "integrity": "sha512-c/1EeqliArkmxSlRmDzbRoNGGMmhsAiCgenWmvJzpWwF3rVoyjF/DClps5GagAO1sbg+6Q1bsxgg3svCEhLdAg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0"
+        "@wordpress/dom-ready": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7412,18 +7412,18 @@
       }
     },
     "node_modules/@wordpress/admin-ui": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.4.1.tgz",
-      "integrity": "sha512-mLveSQCtKHXwRaLtWQa47Dlm3tH/39Oi4x1zSXsoN+0nZbks8iiqg8dvGRoFcev+NV5DAt8VX0Kfc84a3Iatqw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.5.0.tgz",
+      "integrity": "sha512-3hAVtby7FBG3pv+OI7UmAPNOjGbi6JKQrUuDDzlkGsyDWfwZqwaeCU+fx69i/RkI7ZI9RsqWmhCIB3GbljQHVw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/route": "^0.15.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.1",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/route": "^0.16.0",
+        "@wordpress/style-runtime": "^0.6.0",
+        "@wordpress/ui": "^0.17.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -7440,15 +7440,25 @@
         }
       }
     },
+    "node_modules/@wordpress/admin-ui/node_modules/@wordpress/style-runtime": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.6.0.tgz",
+      "integrity": "sha512-PSNzFecFRJ7gmah5YxHFv0a0ZUwZOdeO9/B8GNyv2LgC/ZLXS8CtsAblOKVRO3W7ExwazbHwexaTAOzU/+7Mug==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.49.0.tgz",
-      "integrity": "sha512-SJTVvKAfpXScMoo3NTrY8PPlY2r+nQ9cF+In7mdoHtm9bZrSwYlGCgXGkzNGcTWEjAcu+hzzdj60gcnejPKoJA==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.50.0.tgz",
+      "integrity": "sha512-/bIZWW/SJt4RXL6rZxrlfYd9uYM3r+EvpH5S6sB+9hhrlJA2mJf9b+9Vt9HnxtP8fwX1g7vOLLr5F3Z0GXwnUg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0"
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/url": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7456,9 +7466,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.49.0.tgz",
-      "integrity": "sha512-2JmZWZI5GLLEoRdU1HO8zXUBi+2GR29cjoAomFdGqyr79zNqxpjHoZX0DH9auvMReSm9op8Dq97rSK+4aaQ0zQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.50.0.tgz",
+      "integrity": "sha512-HuHssPsSQQxqlaB6MIDXXG/kLpbloiqYYT49kfPXB4b39nPy/vYmMB+K0J8MB3+HttWMVu0E/4ALQO6qatM1/g==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7466,9 +7476,9 @@
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.49.0.tgz",
-      "integrity": "sha512-y0flsOCZAuVJQpmBp2tWo0kkugxNqTYijfVLamMaXMYJZPxNkHf5D4UA3grsjZtPtJAixFFsOvf8Z10iUQgPIg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-5.50.0.tgz",
+      "integrity": "sha512-WP8qfkYqZgHzLyA7S3ZlwvCgpSVzb9z/93XuwZL4MsS81uhaQ3bIl5e7SnziaMytlo4XULWNbLPLj15EEw7tKg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7479,9 +7489,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.49.0.tgz",
-      "integrity": "sha512-maJY07MuypSy2sHIdzVODKw9WCO0296PvTsMtZ7b19p6HfHHN3/aPzdk+MWC1w+FcAZStCjVCjHVuVvg4r6coA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.50.0.tgz",
+      "integrity": "sha512-nXF+cu0NA9lk4GPO+/iv3mMt1TV9zzjMalfaNPfafWz5VDGW68h82Le8wqclTewex/99kYWl12kHwDIx66hw6Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7491,8 +7501,8 @@
         "@babel/plugin-transform-runtime": "^7.25.7",
         "@babel/preset-env": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@wordpress/browserslist-config": "^6.49.0",
-        "@wordpress/warning": "^3.49.0",
+        "@wordpress/browserslist-config": "^6.50.0",
+        "@wordpress/warning": "^3.50.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.1"
@@ -7503,9 +7513,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.2.0.tgz",
+      "integrity": "sha512-iDPbyyeUnxLFq4ec+03x87jT8lRoBzK2rDoEg24l2KNAR9ZJ2kwI0z2E/wW0fOZC37A7qr377KJslPHKLtMgyQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7513,9 +7523,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.49.0.tgz",
-      "integrity": "sha512-SZNwHk48d9+FNv8LzWJ3PPE9UbJb6BDuiE2sLEv8EvpxWAEQylJmkfWvC3Weegrdz1fn9SeBgtQevjMqfde8uQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.50.0.tgz",
+      "integrity": "sha512-eDKSl+kfhq9wcSuOReor2YFDyih1BrvuzzCI0hXJjBv3IStb65AfzYii4/dYmjipqkJEmjsU7crLr5612EMIdw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7523,49 +7533,49 @@
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.22.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.22.1.tgz",
-      "integrity": "sha512-IOh/zvWQQKeRV+9maUN2sQU9QlwHy8MQ1eJPK5muqQI3MEheaOlTHoc/lE/wI3h2V5TOmWdxFWgi6HSSkMZ1aQ==",
+      "version": "15.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.23.0.tgz",
+      "integrity": "sha512-L/oGA/DHwo4s8MzzqaQ+UegehiujXVo184ttmyhgOzj69HT1P403ju6Of8o4tfRh+2xzH6GIjIOt0HPse9ZKpg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/commands": "^1.49.1",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/global-styles-engine": "^1.16.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/image-cropper": "^1.13.1",
-        "@wordpress/interactivity": "^6.49.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/preferences": "^4.49.1",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-engine": "^2.49.0",
-        "@wordpress/token-list": "^3.49.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/upload-media": "^0.34.1",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "@wordpress/wordcount": "^4.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/blob": "^4.50.0",
+        "@wordpress/block-serialization-default-parser": "^5.50.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/commands": "^1.50.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/dom": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/escape-html": "^3.50.0",
+        "@wordpress/global-styles-engine": "^1.17.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/image-cropper": "^1.14.0",
+        "@wordpress/interactivity": "^6.50.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
+        "@wordpress/keyboard-shortcuts": "^5.50.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/preferences": "^4.50.0",
+        "@wordpress/priority-queue": "^3.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/rich-text": "^7.50.0",
+        "@wordpress/style-engine": "^2.50.0",
+        "@wordpress/token-list": "^3.50.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/upload-media": "^0.35.0",
+        "@wordpress/url": "^4.50.0",
+        "@wordpress/warning": "^3.50.0",
+        "@wordpress/wordcount": "^4.50.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
@@ -7597,9 +7607,9 @@
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
-      "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.50.0.tgz",
+      "integrity": "sha512-iaBZFUv0eL1kxSg5N+suHof7kshaUneqN2EI0eD7elCfpeG76mO3FXgO3Z3Xxv86O6VYRozZw3EbmxLLld0kXw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7607,26 +7617,26 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
-      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
+      "version": "15.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.23.0.tgz",
+      "integrity": "sha512-MUyE7zUOxlHSb3rrzO0kvdv1AqP8XIk8EORf3nf4q2qYk23eU4VsTzlasempM0jc/kdiizineLDYcaNpug3TDQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/autop": "^4.49.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/shortcode": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
+        "@wordpress/autop": "^4.50.0",
+        "@wordpress/blob": "^4.50.0",
+        "@wordpress/block-serialization-default-parser": "^5.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/dom": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/rich-text": "^7.50.0",
+        "@wordpress/shortcode": "^4.50.0",
+        "@wordpress/warning": "^3.50.0",
         "change-case": "^4.1.2",
         "colord": "^2.9.3",
         "fast-deep-equal": "^3.1.3",
@@ -7654,9 +7664,9 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.49.0.tgz",
-      "integrity": "sha512-q1gAcPttohpcmmLFG8nghrsHxCq/LD6ImHfNx0aV/vHc1/bBu3B7MF/E6fqG4WocqHNZbEGfs/a5ktQ4PWu4qw==",
+      "version": "6.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.50.0.tgz",
+      "integrity": "sha512-/5Zn/uIvVw37iLJRa/HhqHQ/DJq4KWjEXTkFQ/NpCNFQm6ll54uDgYZ9f0tWQM7ORCzCU32z/IJ8ujZaMLA9nQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7665,21 +7675,21 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.49.1.tgz",
-      "integrity": "sha512-yqdObGNMwDuvoY95g7GNFfD+W2+NaTlZ2Ms83w7/h9v8sc/rhtgfHoiZNfC6yGw9HE20XZJeoMaSbW4W5DvGEg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.50.0.tgz",
+      "integrity": "sha512-5T6VF6BWXbbTwheNwWBYUcUuXeS5xuXVCFTU3WTj+3SWxx/oU7zACSgdML6xCA50zJiRF/17vez/viyXVL+d0g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/preferences": "^4.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/warning": "^3.49.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/keyboard-shortcuts": "^5.50.0",
+        "@wordpress/preferences": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/warning": "^3.50.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -7693,9 +7703,9 @@
       }
     },
     "node_modules/@wordpress/components": {
-      "version": "36.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.1.tgz",
-      "integrity": "sha512-ZywLHgjFfwFayTs/h7/s/dRuJ7IKafQIjuaKI7XReHHDg5mRV/M1NUGVC6JrBxySGoQ4yMhie+zxc6p1cbthcg==",
+      "version": "36.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.1.0.tgz",
+      "integrity": "sha512-EapV2VXhNIDhWA+yTukQz++IfpqY8gVDvQ9bU8g1RKJqK3dhaVJ9NG2Rqk3TPsFxrmEGNHJwdb+SRUdLFAr3Zg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
@@ -7710,26 +7720,26 @@
         "@types/gradient-parser": "^1.1.0",
         "@types/highlight-words-core": "^1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/warning": "^3.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/dom": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/escape-html": "^3.50.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/primitives": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/rich-text": "^7.50.0",
+        "@wordpress/style-runtime": "^0.6.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/warning": "^3.50.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
@@ -7764,6 +7774,16 @@
         }
       }
     },
+    "node_modules/@wordpress/components/node_modules/@wordpress/style-runtime": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.6.0.tgz",
+      "integrity": "sha512-PSNzFecFRJ7gmah5YxHFv0a0ZUwZOdeO9/B8GNyv2LgC/ZLXS8CtsAblOKVRO3W7ExwazbHwexaTAOzU/+7Mug==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
     "node_modules/@wordpress/components/node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -7771,20 +7791,20 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.3.0.tgz",
+      "integrity": "sha512-nHrV8mLanqnLO67l+6RkotG9eRgiW1D6uVb919z8wVWwoZVfimFyN1nznH92tdE/xW6SnX37XDoLoLcS9IkwhQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/dom": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/priority-queue": "^3.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/undo-manager": "^1.50.0",
         "change-case": "^4.1.2",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
@@ -7804,27 +7824,27 @@
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.49.1.tgz",
-      "integrity": "sha512-jgWFssRW33IPlE50y5DtRdtuNJVlgDr+ZtLsoQvEYb1J/GzgL0uJIIUrdyKHj0tr5FaVZ8RshogN8+oVCpkMKg==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.50.0.tgz",
+      "integrity": "sha512-lSCixe7sRuF2dNK+NcklfBSLsTHZ3rM29c32gw/IvweOlyIuhZc1YaRGhX49T+evLwEhY0yHfGiE6AL/azwlBg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/block-editor": "^15.22.1",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/sync": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/block-editor": "^15.23.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/rich-text": "^7.50.0",
+        "@wordpress/sync": "^1.50.0",
+        "@wordpress/undo-manager": "^1.50.0",
+        "@wordpress/url": "^4.50.0",
+        "@wordpress/warning": "^3.50.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -7847,18 +7867,18 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.50.0.tgz",
+      "integrity": "sha512-bZ5ro1OAeItVhWrcghLI085RgH3TFU6MY1IF9LFmPQxcZyx8syaK7DnYqVIPVNPpGElNyKRX2Se8EwV2cjTnYA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
+        "@wordpress/priority-queue": "^3.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/redux-routine": "^5.50.0",
         "deepmerge": "^4.3.1",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -7882,26 +7902,26 @@
       }
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.0.1.tgz",
-      "integrity": "sha512-MYaMy/fBP/NK9NV4ksUL31DdiskL1rSRvZXN/Ri8/Kx24JexkP5apBgztqc/VNyI2X84i+1RakandeUMB/UZ5A==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.1.0.tgz",
+      "integrity": "sha512-tI09o5MadPL0EoQQQIkuUOOP5ihB6Wf9FNjqwQoZZj/ig3PDD3Ce7QcxWoDWXXQboSVJZnQigXESGuTxxrMtQA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/warning": "^3.49.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/primitives": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/warning": "^3.50.0",
         "clsx": "^2.1.1",
         "colord": "^2.9.3",
         "date-fns": "^4.1.0",
@@ -7925,12 +7945,12 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.49.0.tgz",
-      "integrity": "sha512-6Q7tvwjwNI2W0KDIATd4WAOc1n5Ppp/v/ofOwPjvaXr/9O4s2fsduR//ziQL3c5a5oYohCIsNHSHmOic+/Jofg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.50.0.tgz",
+      "integrity": "sha512-cTRKN9dweiDdRj+NUMsZiEQ0EldKXDNahSRLq8ByJR2TTG73o484SYD0UitcbdIL2DryAYzZ9o57AoRpMaGMvA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.49.0",
+        "@wordpress/deprecated": "^4.50.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -7940,9 +7960,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.49.0.tgz",
-      "integrity": "sha512-0KVKivo1xrjXJpsQ6MmEV9bFAOOxELPgW77hC1b9V9EYdNxnNYSIuXcENMscsM77NW/PAanrEUOkBiWhR9E2jw==",
+      "version": "6.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.50.0.tgz",
+      "integrity": "sha512-YtYtLkAUdLXTCFwLxB/RbpBb19egvOvrEk/aZWxSXBT+sg6fNvTgYvkRMOqaVjja0CWDHGm9DJosZOnvAxuCDQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7957,12 +7977,12 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.49.0.tgz",
-      "integrity": "sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.50.0.tgz",
+      "integrity": "sha512-TVJavTbunFoCSo2g64EKtGwmDVJhvlSqsc4T1EM4aBwsYGIJPjHcAzh6KS8Z171QXFnBxZ7We8CCDAvOFU9iaA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.49.0"
+        "@wordpress/hooks": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7970,12 +7990,12 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.49.0.tgz",
-      "integrity": "sha512-ysZvqyw1PvClTWqVwLzsE7cqfYU+QppJwu2Ji/rUGyFL9WSNdMIgIQhJWZMBiw0gBtD/uuiQe7OoVJfEGw0JYw==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.50.0.tgz",
+      "integrity": "sha512-2Mognc1rwe1+tlIfbSeZPqbuAh6vJagELzw9cLasObiVayWhaG+LCIp0sJz2pPG9ppz8L31gGUgna7zrSRu85Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.49.0"
+        "@wordpress/deprecated": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7983,9 +8003,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.49.0.tgz",
-      "integrity": "sha512-faTCKkv9zjxKKq5RNmA20piRog14+KgAy7/Pw1hbxB1JCsimxFr7f+Vg268TIFbWQJiqX1S+YuKySFGQ/hpk8Q==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.50.0.tgz",
+      "integrity": "sha512-y+nZ8/gm91cV+F6DP1hoQTtYIy+3/YYGQui0lRRgTMOywrlZLt7rDbKBsEsznPOsDo0880LspEOTDX12Qrps8A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7993,55 +8013,55 @@
       }
     },
     "node_modules/@wordpress/editor": {
-      "version": "14.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.49.1.tgz",
-      "integrity": "sha512-bGyu8wC15dHVoAKiDoIV1g91biXGr54t4UjScNhooFkw+gWQ6Y+6FbwmesAruUe5Ew2SKHsnsnj7d6lX/j6qOQ==",
+      "version": "14.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.50.0.tgz",
+      "integrity": "sha512-SOnD4nuE57/LRPxG6nl44GNcSse+VyklTveT234/Jv/K1H6t6ltArejp5gW1SkzjOe8CPn8UPaCOecQ/6Y9lOA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-editor": "^15.22.1",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/commands": "^1.49.1",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/fields": "^0.41.1",
-        "@wordpress/global-styles-engine": "^1.16.0",
-        "@wordpress/global-styles-ui": "^1.16.1",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/interface": "^9.34.1",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/media-editor": "^0.12.1",
-        "@wordpress/media-fields": "^0.14.1",
-        "@wordpress/media-utils": "^5.49.1",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/patterns": "^2.49.1",
-        "@wordpress/plugins": "^7.49.1",
-        "@wordpress/preferences": "^4.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/reusable-blocks": "^5.49.1",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/server-side-render": "^6.25.1",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/upload-media": "^0.34.1",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/views": "^1.16.1",
-        "@wordpress/warning": "^3.49.0",
-        "@wordpress/wordcount": "^4.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/blob": "^4.50.0",
+        "@wordpress/block-editor": "^15.23.0",
+        "@wordpress/block-serialization-default-parser": "^5.50.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/commands": "^1.50.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/dom": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/fields": "^0.42.0",
+        "@wordpress/global-styles-engine": "^1.17.0",
+        "@wordpress/global-styles-ui": "^1.17.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/interface": "^9.35.0",
+        "@wordpress/keyboard-shortcuts": "^5.50.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/media-editor": "^0.13.0",
+        "@wordpress/media-fields": "^0.15.0",
+        "@wordpress/media-utils": "^5.50.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/patterns": "^2.50.0",
+        "@wordpress/plugins": "^7.50.0",
+        "@wordpress/preferences": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/reusable-blocks": "^5.50.0",
+        "@wordpress/rich-text": "^7.50.0",
+        "@wordpress/server-side-render": "^6.26.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/upload-media": "^0.35.0",
+        "@wordpress/url": "^4.50.0",
+        "@wordpress/views": "^1.17.0",
+        "@wordpress/warning": "^3.50.0",
+        "@wordpress/wordcount": "^4.50.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
@@ -8071,15 +8091,15 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.2.0.tgz",
+      "integrity": "sha512-cTnKRHUdZbYAd4RaJiUwhDKdQDDWY7VoGiwektCmhiBQF6WTFYlhsxl/dmHE0Sok3q7PJQwAg538XEb8WuTaew==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/escape-html": "^3.50.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.1",
@@ -8091,9 +8111,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.49.0.tgz",
-      "integrity": "sha512-eOSPRJhmocfi/hztIlbCXbksg54VWIvrbfRbS7AsHY8BelbMyP4YUGEXCZf2jqf5beMB/jqulcsNLsYJ/wC+yw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.50.0.tgz",
+      "integrity": "sha512-EECt++WB1RNPQBwBS7/6rKO4eUNq2xe6nb6Guv6uT+F74DgtM3+aZtNs7JhKFxRMORPtu7T0LhlAOBa4H5CsPQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8101,17 +8121,17 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "25.5.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.5.1.tgz",
-      "integrity": "sha512-u2LsmTVstDQqV98gvKA8NiyDhARE5XbLd5syz5lCZu/nf2rj6HYC5ttFsjORVFfdwGXVq0HAlIKaHN41r8jOEQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.6.0.tgz",
+      "integrity": "sha512-TZ1M+S8gk0MltuF2WsiNG4sjIUvaurB036v4QL81HM3DsfjPFOpKykyWswWO/iZv/e0f/ryG4O/aDfMbU+oEHg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "^7.28.6",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.0",
         "@eslint/compat": "^2.0.0",
-        "@wordpress/babel-preset-default": "^8.49.0",
-        "@wordpress/prettier-config": "^4.49.0",
+        "@wordpress/babel-preset-default": "^8.50.0",
+        "@wordpress/prettier-config": "^4.50.0",
         "@wordpress/theme": "^0.17.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^10.0.0",
@@ -8175,37 +8195,37 @@
       }
     },
     "node_modules/@wordpress/fields": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.41.1.tgz",
-      "integrity": "sha512-CiOY83zXLcFs01imrYGeC+xdxc14+bXj5QaUNA9fRoN4pR/CKsbMatSXsE+HgrcCgivHVOSDr4g+Df5sP65glQ==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.42.0.tgz",
+      "integrity": "sha512-Nbb5FkYFRbFtdW4h74e37GLs9kZPiMNUQzgI0j4Rkiv55cRU1088x9XzZ6KslIiySazzCmK2/wWoJUXPwNUQRQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/media-utils": "^5.49.1",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/patterns": "^2.49.1",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/router": "^1.49.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "@wordpress/wordcount": "^4.49.0",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/blob": "^4.50.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/media-utils": "^5.50.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/patterns": "^2.50.0",
+        "@wordpress/primitives": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/router": "^1.50.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/url": "^4.50.0",
+        "@wordpress/warning": "^3.50.0",
+        "@wordpress/wordcount": "^4.50.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
@@ -8226,15 +8246,15 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.16.0.tgz",
-      "integrity": "sha512-fopMEmf/nwwe2JFlnk2t158bBHAPUnmXEctCFdQyUboi2Zb7VuY+bam4YQ9hhuP4wRhJHWPCyt+ZOrHgST1OBA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.17.0.tgz",
+      "integrity": "sha512-/RZMt/BJsxBSOratwGJsFypXZ4fegaN2iWOWz6PQd+s1UPBL31z/WZ6bugDGNAn/U6CbmbN+Bh/AceH30tsuSw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/style-engine": "^2.49.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/style-engine": "^2.50.0",
         "colord": "^2.9.3",
         "deepmerge": "^4.3.1",
         "fast-deep-equal": "^3.1.3",
@@ -8247,28 +8267,28 @@
       }
     },
     "node_modules/@wordpress/global-styles-ui": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.16.1.tgz",
-      "integrity": "sha512-3aJpCG5LVfk7u2iKcWA9SzEOyso2D/6+Q3XeZcXXdKELCH7nNjm0qk/LT95aloCI4pAUejE3XHi1V7VUOp7W0Q==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.17.0.tgz",
+      "integrity": "sha512-X59069uJKh+9gjjuq4fcNVE87KGiIEeFcAZfw6kLal3Zo2VS2Z9yQdGH1E+NpowHQbCcN9kFY5GGdkMqy/UiEQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/block-editor": "^15.22.1",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/global-styles-engine": "^1.16.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.1",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/block-editor": "^15.23.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/global-styles-engine": "^1.17.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/ui": "^0.17.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.9.3"
@@ -8289,9 +8309,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
+      "integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8299,9 +8319,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.49.0.tgz",
-      "integrity": "sha512-/ZYK6CPks3VAGFQZ+h56jOy4LB4CC1ZB1SMVY3eeUPStyH84YSz7nTa2P7gw/4uGJhaITMQCmFl7yGFPQOROtg==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.50.0.tgz",
+      "integrity": "sha512-RWoT58IXeX82fC7zBLiTNEDdKN/fTAHWlMJbEwMH65UTzJt5jNWtmVdbtTZP248ceyAK3lUsWaXei2t1bqAyNA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8309,13 +8329,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz",
-      "integrity": "sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
+      "integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.49.0",
+        "@wordpress/hooks": "^4.50.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -8329,13 +8349,13 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.1.0.tgz",
+      "integrity": "sha512-KPFEe24QJ5MTp6XMREKPPW1tHWjQau/vwYuZqkddSiJEhUBSrNaDHRqneCMC6WVhWCSmWNJcjUtdkFQpLb5W+A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/primitives": "^4.50.0",
         "change-case": "^4.1.2"
       },
       "engines": {
@@ -8353,14 +8373,14 @@
       }
     },
     "node_modules/@wordpress/image-cropper": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.13.1.tgz",
-      "integrity": "sha512-zSpZWZoMl+oaE3WQNYLZmy11vEEuQElPedgL5xO1qivlfHxa2ZgfuIwdb9AdiwQodsv1HVkbD4sqXTqsKtJDzw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.14.0.tgz",
+      "integrity": "sha512-Uu441xNKPfGcSr52obC3AoyXr++8t2Iepsk1XG0rXHE5OW7xbEit8fMwrn3lxQL4sZ78UFTI8ojNsieCpKK3RQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
         "clsx": "^2.1.1",
         "dequal": "^2.0.3",
         "react-easy-crop": "^5.4.2"
@@ -8381,9 +8401,9 @@
       }
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.49.0.tgz",
-      "integrity": "sha512-hGgqxXfkSEHFdQ+AnFvnBERlNT7B1+l7yYahRPhBA3jms1JNsB0DZZDSpUq292T5yxfuV6hD5uebFpucS0PsCA==",
+      "version": "6.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.50.0.tgz",
+      "integrity": "sha512-jScebsDZocz/l+vbutSpR8U5zZweb1rQzHPyjncHTmYqTCSGoYiGajS/lIZvTYQ2Ve4V0wTaeS2GuaFuWTEHxw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
@@ -8396,24 +8416,24 @@
       }
     },
     "node_modules/@wordpress/interface": {
-      "version": "9.34.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.34.1.tgz",
-      "integrity": "sha512-xNZXm1BQKbRl1HA64lSkwzKmm1wFn7LsIEsrmoQ3LNv8ULF6Hvq0P4lkuMF/4oKY5epTHZ/7yZ3UxvKFlHFq7Q==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.35.0.tgz",
+      "integrity": "sha512-8hclXI83kE4BKbsiHFbb4csebt7NUUfXFdxZAlXoTJblbJABptU6lm2kpL122L2SM/qnzQfA7FR4vhtH2ooRIQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/admin-ui": "^2.4.1",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/plugins": "^7.49.1",
-        "@wordpress/preferences": "^4.49.1",
-        "@wordpress/viewport": "^6.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/admin-ui": "^2.5.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/plugins": "^7.50.0",
+        "@wordpress/preferences": "^4.50.0",
+        "@wordpress/viewport": "^6.50.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8426,9 +8446,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.49.0.tgz",
-      "integrity": "sha512-pKvFYoExyT/A5h0Y5wLYs+8gQRaisJps2YF0jICo/LOfXR+TF8mYLH2txrA8ZCDGS0FPLSPjMxAl9hjUGrELRg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.50.0.tgz",
+      "integrity": "sha512-Cq1brW/OhGVNnCqSztHgmKQ1DsNUtEq4F1xIo1awBKVmXDWFggJRxzaWZHWC+sDZmBp7pu03jWqq2u/s+hazSQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8436,9 +8456,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.49.0.tgz",
-      "integrity": "sha512-CaRm4xsTybCh8gfy/nyOa/6ujRePFVnGFcI4Cl0xKY5pw1YpYVQOBEad1a4j+EL/hNqFa1W++xZw2TLOs/zw9w==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.50.0.tgz",
+      "integrity": "sha512-iV6h5nWylCrL/4Wt7kXvq8YRwhryLgxThliaPLVvMfHb4CM6MJzapoIw5l8YIs1CDRlBU6N9j9oAxLBXvhrHqA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -8454,13 +8474,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.49.0.tgz",
-      "integrity": "sha512-yDUkAnY4ztoTL59sRgULaF1sxHGzemrMlS9xo11RRbDx9HYcrybjX/X37ABlGwCzv+AmsolVcRfyfmsAxHeJwQ==",
+      "version": "12.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.50.0.tgz",
+      "integrity": "sha512-FA3pe0WMMg0l3l3/pumjX6rhKJXikO6BBRb/3ZeprD0xql5CTx30D7cKl0neluNjeZ2bd+1C3KYSvL81i4Y77g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.49.0",
+        "@wordpress/jest-console": "^8.50.0",
         "babel-jest": "^29.7.0"
       },
       "engines": {
@@ -8473,14 +8493,14 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.49.0.tgz",
-      "integrity": "sha512-Md7+yO1CCUMqMD5ChpPoRQ5GJ+DAsXs0eEJIFrQXbU63QsIYwIdylT6+WelfWDeB2cLCodjWg0j1vL1S1kjvEw==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.50.0.tgz",
+      "integrity": "sha512-8ytzJgkdukPrOBpMUFp0LhTd2V5LmIknYM1o9p5AYgw+TvuV5rkxXbJR+b5MaWeVVJxwL316rgWW6ojQzco8iA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/keycodes": "^4.49.0"
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/keycodes": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8497,12 +8517,12 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz",
-      "integrity": "sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
+      "integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.22.0"
+        "@wordpress/i18n": "^6.23.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8518,28 +8538,28 @@
       }
     },
     "node_modules/@wordpress/media-editor": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.12.1.tgz",
-      "integrity": "sha512-9isu86PcbSpzgqrtPJ8roPafv2rvybATAhNQ3rPHsUA6pigZNP3S1rjQNqUDGiXXJPxkXda4GsUU/ndLJpKwbA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.13.0.tgz",
+      "integrity": "sha512-1MniqSxi5fMBfju8dEZUsbBqUXkYrRArk/RRMNLvYocFwFf5DXbWm2g/nPwq24LDmj4RbxqMAzp3hBCXxvo2qg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/interface": "^9.34.1",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.1",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/interface": "^9.35.0",
+        "@wordpress/keyboard-shortcuts": "^5.50.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/ui": "^0.17.0",
         "clsx": "^2.1.1",
         "gl-matrix": "^3.4.3"
       },
@@ -8558,24 +8578,24 @@
       }
     },
     "node_modules/@wordpress/media-fields": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.14.1.tgz",
-      "integrity": "sha512-CGQ52QD+l2HwJAKjHTbTzbB7yEDTbvt4MF9EuogoOI3p/rAZI8aC1fNT1gBoEXXa9TBifURLOBuHd81JWLJqOA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.15.0.tgz",
+      "integrity": "sha512-pn7D5EvAuT7qdMefclfQv+X0czQi2elID+i/CgFORhN5PlEsMthVPJ+25r+iqHqXtN9BxRNat2aJCIg+nxW7yA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/url": "^4.49.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/date": "^5.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/primitives": "^4.50.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/url": "^4.50.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8593,26 +8613,26 @@
       }
     },
     "node_modules/@wordpress/media-utils": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.49.1.tgz",
-      "integrity": "sha512-Bhzu52ajcXD2WPMO6KJiW5ArjZTdtRw37HYZGNxww8TyArlfE17Fn5l27lpdi1BU7j7+P6Axc9KvHiPNBklHIg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.50.0.tgz",
+      "integrity": "sha512-VXTEoF5JE5QCI0JF8r3NZcD/0P2TJQmW2XAAnB+yxonMr3AQzwdQLQNl5YGIdy8NaCF4YybckInyPxtVJ7wt4Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/media-fields": "^0.14.1",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/views": "^1.16.1",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/blob": "^4.50.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/media-fields": "^0.15.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/views": "^1.17.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8630,14 +8650,14 @@
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.49.1.tgz",
-      "integrity": "sha512-MuPU8NbEns04Ael1BjeodGV0TOzRZp6FZ6M2qXhCQQU+0EjENkattxetEdQikWRbVwFj2+Wht7lO5W5m5noXqg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.50.0.tgz",
+      "integrity": "sha512-5SbGOxvgme21Slf1smiWRh4SFmL6mbMrPPcSOHHwkqxlCOZu9dp5gXGQbJNYz9arLqOIHze6+o1/8gsfJJNtPA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/data": "^10.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/data": "^10.50.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8655,9 +8675,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.49.0.tgz",
-      "integrity": "sha512-1Fshw6Fym+4ocePqRyvRhFI5zpw6n4FU+3MiQ9F6kVibbuhpssDAlO/wC6saRY9gl1xjTilLJSVj14WvF+ZeVA==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.50.0.tgz",
+      "integrity": "sha512-gI3vGO+R/kxUexTN2KfSy39ctg7QvOldZkEDZ90VVjK8Z6l46Uy5zvfMm94C6d5T7TgM9vcUkQghUd5ze0MXXA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -8669,27 +8689,27 @@
       }
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.49.1.tgz",
-      "integrity": "sha512-vh/VItHDMYIbcN3xmEuXSCSheBJ/hP4UMHQ1e9MYm/ifJuehPoeWqwdoca9nQ2El9N2dviBbB6DEKzy6bQrO/A==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.50.0.tgz",
+      "integrity": "sha512-4MQcHrHmRqAT++XMJ6ExX0/YQpVlZvNPXR8VsrCvOxVEXA8tINStPbMgYzbduHBMLGzXI0eMVDG8ND9g0Rz00A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/block-editor": "^15.22.1",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.1",
-        "@wordpress/url": "^4.49.0"
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/block-editor": "^15.23.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/html-entities": "^4.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/ui": "^0.17.0",
+        "@wordpress/url": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8701,18 +8721,18 @@
       }
     },
     "node_modules/@wordpress/plugins": {
-      "version": "7.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.49.1.tgz",
-      "integrity": "sha512-L1APErAQkwI/Qxf+eSWj3M3ZCDqbIstKkufmPuqjaV1vCrvcPIi1R82Rz9TzeKXB+TM1jb+Ob36UVpSDyONKMA==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.50.0.tgz",
+      "integrity": "sha512-oB83s38e94JD+M/5kyimlTfNQ8V6uXd2gbRkC+hZ28ZSNuC/pueziWYVE0BeTmESaVWtOjxE7ywWIuGdGO2N8g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/is-shallow-equal": "^5.50.0",
         "memize": "^2.1.0",
         "react-is": "^18.3.0"
       },
@@ -8732,14 +8752,14 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.49.0.tgz",
-      "integrity": "sha512-K117Ge7DVVkm89EAITbP0LgSI3wZluThwET4/E4+/pX5AtYvj9jFmXpOAr+tiBt4qvHcCL6RRBUcRSoVP5W5Lg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.50.0.tgz",
+      "integrity": "sha512-uDpgDTGpHjjNHS+3E0hss0otRYeKVYulO2TA7jTpcXh9gikRCJYCQtFHh/eUCETrvSpzzfzIiKT7I048brWrcw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/browserslist-config": "^6.49.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/browserslist-config": "^6.50.0",
         "autoprefixer": "^10.4.21",
         "postcss-import": "^16.1.1"
       },
@@ -8752,21 +8772,21 @@
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.49.1.tgz",
-      "integrity": "sha512-Znmh5CyAan+NoaQ4VPCDVyQb35/mPtVyuAV8aa2eViQMya2aKXoVpkVSvHfRrWb6Z1iEvDYZjd5OYgn3mXOb3A==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.50.0.tgz",
+      "integrity": "sha512-KptPNtUWvuI6qQ0NafXjgRJoU5M3gwcSDtX0xB4BCwOBfJycSz+v+GHaMlOEs3ZOJpdsq9zXtCt/psG88z+7ew==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/private-apis": "^1.50.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8785,9 +8805,9 @@
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.49.0.tgz",
-      "integrity": "sha512-yP4hm2m2Hxv3I7HI5lxbrCmh95Db4QWcGJGLq/fysepbLjTnqnMIHRs5p0/QoRMV/MhwFi8vMkNmmQYJt386ug==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.50.0.tgz",
+      "integrity": "sha512-Q48oFBORY0TiVWIebPOG0ynjUAq1Hi9gXKJ69xw2i/UwOwghLOXXFLdAQhS4bJXOw0cdV5xiBaXEQYU+82r5hA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -8799,12 +8819,12 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz",
-      "integrity": "sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.50.0.tgz",
+      "integrity": "sha512-X/Vf1BUwPsxsyJq+z2UwjOHFoT4p1XI0VoxgN2JsbK0ZwbLPA9PQur1hGw9ujXqNZ4XG1U2rQ0aM+3yap7iC3g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^8.1.0",
+        "@wordpress/element": "^8.2.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8822,9 +8842,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.49.0.tgz",
-      "integrity": "sha512-UcVHYan6qYvDNTFEwEnPBU9I1SnImLjEh54ISgqvvndc7jfxtdi+Akwj2kgxeLRY+bsXzMQr6byD/x4dw56yqA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.50.0.tgz",
+      "integrity": "sha512-OyuAplepKQpNYr8z+nGGGNXWK2v2u9Bqnawkg7V5YkvOKYj/iBJNCiUxiWXOBMeLF1ze36RDR5LEcNDmXRev2Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -8835,9 +8855,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.49.0.tgz",
-      "integrity": "sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.50.0.tgz",
+      "integrity": "sha512-bCVLL9YuWfnPNNqlhl4eTKPipjWbJ8MzAlasJ/SR+h979MyeMFjNPapxKqsPqnJOhDEVSdCTkRN/Wa+Xk8qFdw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8845,9 +8865,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.49.0.tgz",
-      "integrity": "sha512-pisFM/iQv23hmrBkWwlQZoMtqR3wXWoaAAf9d++laxlPRkFNfe/AG7gUK9tljhk5k6lP9pdeet4t+qSeQPDxpg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.50.0.tgz",
+      "integrity": "sha512-flSjGWuU5C2CrH4hommSDyN0Zz+VRDTUvclLbpByRmUc8gsfgscmjJo+99o1KvU/f7ApItRdFKkbjdxzwtXorw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8863,23 +8883,23 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.49.1.tgz",
-      "integrity": "sha512-oV0mUZqez0xf28h8E3AvzhX49xHvYDnjB4l6TgZgH4FzZ/N1bk6z5Tr0agaR/RgPOMeka1zQwGnPSyFVXjql3A==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.50.0.tgz",
+      "integrity": "sha512-vMVodLA2Oy7+rzAdCe+UDwT2kT+Gj8K1Vi3CKYjfXRu4Aeu7BQzRMY0H3BEkTQZlkiQs7ebgEFuVC0SEkrJfrA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/block-editor": "^15.22.1",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/notices": "^5.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0"
+        "@wordpress/base-styles": "^10.2.0",
+        "@wordpress/block-editor": "^15.23.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/notices": "^5.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/url": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8891,21 +8911,21 @@
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.49.0.tgz",
-      "integrity": "sha512-RDH3dAnPTimIXYEdJ5+20KyJgmCeEDouA4Hi1Jhl1fiAzjjH1lNcwgs9eNQzaagqQTLfvvWOPX62rkFJnSvvvw==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.50.0.tgz",
+      "integrity": "sha512-i3lFUjzeIx+0xWoWUWKIcr5pWyT6D75JlMnB0wgLE5hyaI1NUryUziOohW9b1j6xKvY1CS0j6JJVmnJAmHXHsQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/dom": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/escape-html": "^3.50.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
         "colord": "^2.9.3",
         "memize": "^2.1.0"
       },
@@ -8924,14 +8944,14 @@
       }
     },
     "node_modules/@wordpress/route": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.15.0.tgz",
-      "integrity": "sha512-lkktJdVVWsXZACrplhRjUoOMHKV0lq7tIWxERAA8nr8BmPMNG8HGKVJ+mXi82n2TI0/nfFXV0p8g7DcX59+pbw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.16.0.tgz",
+      "integrity": "sha512-H4JzPDmrujjo0k5vHomCNPibsnatEEQdR9+xbEc8DRIpL77SO9o5h6yKVxuOgaj+uYSWGrQNnISSRfhQqq3+Pg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tanstack/history": "^1.133.28",
         "@tanstack/react-router": "^1.120.5",
-        "@wordpress/private-apis": "^1.49.0"
+        "@wordpress/private-apis": "^1.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8942,15 +8962,15 @@
       }
     },
     "node_modules/@wordpress/router": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.49.0.tgz",
-      "integrity": "sha512-Ihs3B+xyWfAGR1IHEsw2bIPD2wgqs/R+2Uwlq+D0069goUEULBRj6ooSJgs2FsbR1lEyjtK1KLBgZE9TOXhRIg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.50.0.tgz",
+      "integrity": "sha512-sQjUfnS4lYf+51YJO3TdNCXrnbhadsO2PS5Gop4zCumVoJyctZHHJ29XAzC7KDxK0npRqIZYQCqIJ3Even6yiA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/url": "^4.50.0",
         "history": "^5.3.0",
         "route-recognizer": "^0.3.4"
       },
@@ -8969,25 +8989,25 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "32.5.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.5.1.tgz",
-      "integrity": "sha512-eiFb6nw+hYkcGn5eobZbIx64cnBTIiPO0tt952oHPTk1XngwNVsxgR6qBT37f/niCPKM71kpst9VkjGybQV0Nw==",
+      "version": "32.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.6.0.tgz",
+      "integrity": "sha512-nO5s2RYmOWiVjcG3/zp5NEejLu+J/dzujRIl633hd9yj8gBtQRKfZr/iAwyFQwW0Asn15bbwc1I0b4+lvnumOw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "^7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.49.0",
-        "@wordpress/browserslist-config": "^6.49.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.49.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.49.0",
-        "@wordpress/eslint-plugin": "^25.5.1",
-        "@wordpress/jest-preset-default": "^12.49.0",
-        "@wordpress/npm-package-json-lint-config": "^5.49.0",
-        "@wordpress/postcss-plugins-preset": "^5.49.0",
-        "@wordpress/prettier-config": "^4.49.0",
-        "@wordpress/stylelint-config": "^23.41.1",
+        "@wordpress/babel-preset-default": "^8.50.0",
+        "@wordpress/browserslist-config": "^6.50.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.50.0",
+        "@wordpress/e2e-test-utils-playwright": "^1.50.0",
+        "@wordpress/eslint-plugin": "^25.6.0",
+        "@wordpress/jest-preset-default": "^12.50.0",
+        "@wordpress/npm-package-json-lint-config": "^5.50.0",
+        "@wordpress/postcss-plugins-preset": "^5.50.0",
+        "@wordpress/prettier-config": "^4.50.0",
+        "@wordpress/stylelint-config": "^23.42.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.2.1",
@@ -9118,9 +9138,9 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.49.0.tgz",
-      "integrity": "sha512-xuhny4GqmKBVVfrPzeJ/d+oa+v71184B9jSeZBE9dsXl4Cp61GIM0TLNwc24p8sO2vhv+eleRQMmRvMLfOCroA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.50.0.tgz",
+      "integrity": "sha512-P55NxY86M8lNnAbEPmpEswbxBoB7BWVhg67KOLRsGwLMeJ4qHbBngmgBIUt72IAH3H2UWVq7jZ1Xm/J1ENOMoQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -9360,20 +9380,20 @@
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.25.1.tgz",
-      "integrity": "sha512-bxRtJZEGtWp+yqzdgMhMC97UkfFNTsJrV0mLGkj0Bwso4H7LENs7JRYdckmTjMKHwqHen1hrXO1rNpnXdjYaPQ==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.26.0.tgz",
+      "integrity": "sha512-WpUX18WldmLZe9JYbJRkw95qCyZO1CuHAj9ET1KVjiKGsMO92O5RwufWc9txa7YSXDlyEDXt5jwSmLh2mgGaIQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/url": "^4.49.0"
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/deprecated": "^4.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/url": "^4.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9391,9 +9411,9 @@
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.49.0.tgz",
-      "integrity": "sha512-RG+uTFRjbBxdFNy6S6AEnafC6LeFfcxombbPf+F++/DidCwNw3xUe1TYl5jkda7j2ywTGwopk0VC2vtqG2ZXwQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.50.0.tgz",
+      "integrity": "sha512-mMPHJr3UT6Z4wlU+q/61S6Cv6j3zcyd96AhVfJHXSxhZbjgTXkX+zhi79jt12Xnfzz4A6FfXTFCuwVV6Jvz1ZQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "memize": "^2.1.0"
@@ -9404,9 +9424,9 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.49.0.tgz",
-      "integrity": "sha512-U3T2Ss3UtTqBnd6UpFRhDCQyB4XDG1HJbR5tWDx6UjbjgadeAX5+8WqnZumeWd5H/ZRax1WFLs8eqKvRUZA2mA==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.50.0.tgz",
+      "integrity": "sha512-7iAvYbPniJ3fBV2S5zRVDdNqHLWKsXZlx6/IqVz2uOASXEn/qTACqf+nWv2Az8lJkKyXUmO9EWBrGTOvGX0ulg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "change-case": "^4.1.2"
@@ -9435,9 +9455,9 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.41.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.41.1.tgz",
-      "integrity": "sha512-+QA9RKPFCCE3DiVRdy6GDzbOmXtxwty+yEIx8tbOMZQHEW4uPQtH6k5Y2Q+qT9jb2os2skb0O9X7jOwH9PGm9Q==",
+      "version": "23.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.42.0.tgz",
+      "integrity": "sha512-k9lNU4sK3fdipdhHI2d/Rzd/NnfznPmOZ60ok8O8QhfCMZw2Jd1M8ckYqaIrHTKU62ZrcsugdfJlHodsdrxEzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9456,15 +9476,15 @@
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.49.0.tgz",
-      "integrity": "sha512-qjMcjVNk4Zzr6LYEvoNBmZU/ja9jSLPOUhVwIls818LJr7lLs2mMf47gpqFpYv7M0GIDl63zRbQHUFuEPmJHfA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.50.0.tgz",
+      "integrity": "sha512-Ig0qHewnNEea7XHlFxgMPE37WMjTyOQRuboQxxVtVYXwyWgTQI83+AE9jc8cKQ051dk1UDoAwa+Sd145/79htQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/hooks": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/undo-manager": "^1.50.0",
         "diff": "^8.0.3",
         "fast-deep-equal": "^3.1.3",
         "lib0": "^0.2.99",
@@ -9522,9 +9542,9 @@
       }
     },
     "node_modules/@wordpress/token-list": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.49.0.tgz",
-      "integrity": "sha512-J1wgnWSEcQQcEOI0TJv1orP1eGa5nuo85hqhIptuQBYEU3vRqCTOn6z73xIJ5R0tWi+8pkedJQxl170zJ/Aifg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.50.0.tgz",
+      "integrity": "sha512-NgmApEUrObbO67/9GHoYpmO4gS/iWpfiYt56JohFXUSbk3h3DJ1kILkxL3k0KDfeLoQRtwWiPnB6Q4Ez89IUjQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9532,21 +9552,21 @@
       }
     },
     "node_modules/@wordpress/ui": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.1.tgz",
-      "integrity": "sha512-kJw2wcFTpQ3NcebbKiXqwFTSLgKwt0ZTukcaxWgsYRVdb2bAmCSEpq8qpLvEN6bqg4JUkuHNlqRguQNdIsXGZg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.17.0.tgz",
+      "integrity": "sha512-+mMnJmkvFjTk7veIioU/idaPfb6HJCcBV408v1gKsbpLa+dxG+rLdlrpzJILLlZmHUyCrJXk9EmYZi6MkFoL9A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
+        "@wordpress/a11y": "^4.50.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/keycodes": "^4.50.0",
+        "@wordpress/primitives": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/style-runtime": "^0.6.0",
         "@wordpress/theme": "^0.17.0",
         "clsx": "^2.1.1",
         "tabbable": "^6.4.0"
@@ -9566,13 +9586,23 @@
         }
       }
     },
+    "node_modules/@wordpress/ui/node_modules/@wordpress/style-runtime": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.6.0.tgz",
+      "integrity": "sha512-PSNzFecFRJ7gmah5YxHFv0a0ZUwZOdeO9/B8GNyv2LgC/ZLXS8CtsAblOKVRO3W7ExwazbHwexaTAOzU/+7Mug==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz",
-      "integrity": "sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.50.0.tgz",
+      "integrity": "sha512-599I3GPXSMpmAE2jqzHteqypI7rdt5HPDAw8GrHMkDWR1T9gK2L3gObv8I1Hs4eSDM88wgAB0Ifnqpy7zPn5rw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.49.0"
+        "@wordpress/is-shallow-equal": "^5.50.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9580,20 +9610,20 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.34.1.tgz",
-      "integrity": "sha512-EqjtPQaYUy0SXrMfx78r1S4pRqg8YeKSQ4lDxSn5Szbu0GmLGXHRfgmb3vHa7FhN1w0T8J1ZgUmVodWnGZab2w==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.35.0.tgz",
+      "integrity": "sha512-Xpka03EVJZd0BORFsgYZhGnrSHwolwXkDR+g4S+VQoWOCbhZSX9VRPgEiPSxzp3i4HTCvgXyeEo6sEKNrhlllg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/preferences": "^4.49.1",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/vips": "^2.2.0",
+        "@wordpress/blob": "^4.50.0",
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/preferences": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
+        "@wordpress/url": "^4.50.0",
+        "@wordpress/vips": "^2.3.0",
         "uuid": "^14.0.0"
       },
       "engines": {
@@ -9612,9 +9642,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.49.0.tgz",
-      "integrity": "sha512-u9Mbph1qh3ZUm2p1HC267frFA1Eg4edC9tagfACxU79p77SKp3loiwfRPM64i50xna8S0wfPwBr0oLF00NawvQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.50.0.tgz",
+      "integrity": "sha512-k9lJLhDDzuNfoI3LAXVqTocYQxQJcH2ee08uy9fPd7l8JgfkGmFRm4zWnyEncZn2n8SG19kC4t6MvykaQZk9Gw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "remove-accents": "^0.5.0"
@@ -9625,14 +9655,14 @@
       }
     },
     "node_modules/@wordpress/viewport": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.49.0.tgz",
-      "integrity": "sha512-JZibnYTgB7oYdp4CKmmb8ovhRmw9qFTBLI7FuGv0QZ0NUh5k2mDKVzP29VcnDb16f/CNMeJU60ZuCQq7/rcr+w==",
+      "version": "6.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.50.0.tgz",
+      "integrity": "sha512-6GfBrVMsPLQAmecIgwYcZbvbB0Ftm95bzRnWf5rD6oQXnEdUAFZ9vuE7iKxEfHHU9GXswsDD8Ko8eseDLpjS2A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0"
+        "@wordpress/compose": "^8.3.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/element": "^8.2.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9649,17 +9679,17 @@
       }
     },
     "node_modules/@wordpress/views": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/views/-/views-1.16.1.tgz",
-      "integrity": "sha512-zlwY10PY/Tqe8b78c1E4HMO8HWJ/IAFxs8XrH9sQVmb/uuRiFoJmIowXmE3CL1zBqLOWmrl6KSZK5tetlHwzqA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/views/-/views-1.17.0.tgz",
+      "integrity": "sha512-vYjzvAMJPRxu920QL6x6ZedJX5uf3gg0VKoUMYrRNUUS21atyndSBAB+SJ03VQHlwysyN5tvhtxiN/OwiF5rQQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/core-data": "^7.49.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.1",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/preferences": "^4.49.1",
-        "@wordpress/private-apis": "^1.49.0",
+        "@wordpress/core-data": "^7.50.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/dataviews": "^17.1.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/preferences": "^4.50.0",
+        "@wordpress/private-apis": "^1.50.0",
         "dequal": "^2.0.3"
       },
       "engines": {
@@ -9668,12 +9698,12 @@
       }
     },
     "node_modules/@wordpress/vips": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.2.0.tgz",
-      "integrity": "sha512-3GC+P/SC5/tqshTUe1vAARVpL/sCQU3Qvn6nmECfEldJY5ViBUM+yW0jcqNVkcMCd6WQsjSHcwozgx6BjtHCqg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.3.0.tgz",
+      "integrity": "sha512-MeJZckJBJOjEe9htBQysYjfqKdbqeaSOEKtGMgqY4Jlt9EUUyc9LknLKwxlFR0Km/AW7b+8J2j5Dx5gNLwN9QQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/worker-threads": "^1.9.0",
+        "@wordpress/worker-threads": "^1.10.0",
         "wasm-vips": "^0.0.18"
       },
       "engines": {
@@ -9682,9 +9712,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.49.0.tgz",
-      "integrity": "sha512-00KmZy5kT8vm48HKNQxsgiq3GXdgaPGClneMFTe9EWjop9Ghyq8MaYIqjYY75eOgPTFVcKKQyXK9/DAAQxsQuA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.50.0.tgz",
+      "integrity": "sha512-6X3ioKOGfmRuZFngmG2QZZW9CBVMTBr5FXqs6Q3li5ryhnAqn3u/ocqsx556YnB5dYdVxK14TiH9o7DDElt8gw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9692,9 +9722,9 @@
       }
     },
     "node_modules/@wordpress/wordcount": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.49.0.tgz",
-      "integrity": "sha512-4UkZySzJKxnu4t0+t+nxW/j+8pOPbc96dp7/v1SffAdGRABik7V7vEpvL9NN3e1FiZgrbtwdWK2P4zsvJzMg9w==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.50.0.tgz",
+      "integrity": "sha512-rWJkzoBEkcQF7/y3K39K8bPHDXzWEGXJ3iQgYCnpca4/m3lzP1eRQKX9B/X2zicqW4K7l1h9jui/F5fdj5bcSw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9702,9 +9732,9 @@
       }
     },
     "node_modules/@wordpress/worker-threads": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.9.0.tgz",
-      "integrity": "sha512-UAOns1u+ZljgJtbv07kSIWzVCUSXCxk5KDSQgw4Sx5MKOHqcuNoF9p8HorE5DiAOgJA01CxxXLs03peTF65X6Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.10.0.tgz",
+      "integrity": "sha512-sW/yKL5OE/Ke9X3itP4eICcbFANfRkuMtoUDTtSRqxZZoupZuDeXvxgjhNYTIBzfJnA79I0k5PKB4lu5VGCnGg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "comctx": "^1.4.3"
@@ -10674,9 +10704,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.3.tgz",
+      "integrity": "sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10793,9 +10823,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -13455,9 +13485,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.382",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.382.tgz",
-      "integrity": "sha512-8ETaWbV6SZOrno+G93Ffd9ENsMtetqdnqj4nlfxFW90Sm5GgnuV28Kf62hqQVD6VUgzm7qFQKsTsAPmeUiU3Ug==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -13757,9 +13787,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14071,9 +14101,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20963,9 +20993,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -21975,9 +22005,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
-      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
+      "version": "10.29.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.4.tgz",
+      "integrity": "sha512-GMpwh9+NJ8tSmqwIaVyFRQkiKfBEzQ+k7r7tle4W+kaJ+7wJiB9hFz9BixAomMtenPPSBfM4bZhXozGxhf0uFQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -25596,19 +25626,19 @@
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.5.tgz",
-      "integrity": "sha512-z3Rymka5QtcwJpSaFgEzZwX9AsL4JYMEhicH9XKOwEHSmVerFLjFubiLXtNTjMDUsrFhbN9cfv5cXYIGZkcVjA==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.6.tgz",
+      "integrity": "sha512-T7sT7XcBzPJY5OJo7DIFiH9Wbh7iO1rBXHq681Caghnke9EjXTNXsuJ/re03TzGBB7DWWzQ6sDcYtM1rfRMHVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.5"
+        "tldts-core": "^7.4.6"
       }
     },
     "node_modules/tldts-icann/node_modules/tldts-core": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
-      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
+      "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
       "dev": true,
       "license": "MIT"
     },
@@ -27367,21 +27397,21 @@
       "version": "1.1.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^5.49.0",
-        "@wordpress/block-editor": "^15.22.1",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.1",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/editor": "^14.49.1",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/plugins": "^7.49.1",
-        "@wordpress/server-side-render": "^6.25.1"
+        "@wordpress/api-fetch": "^7.50.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^5.50.0",
+        "@wordpress/block-editor": "^15.23.0",
+        "@wordpress/blocks": "^15.23.0",
+        "@wordpress/components": "^36.1.0",
+        "@wordpress/data": "^10.50.0",
+        "@wordpress/editor": "^14.50.0",
+        "@wordpress/element": "^8.2.0",
+        "@wordpress/i18n": "^6.23.0",
+        "@wordpress/icons": "^15.1.0",
+        "@wordpress/plugins": "^7.50.0",
+        "@wordpress/server-side-render": "^6.26.0"
       },
       "devDependencies": {
-        "@wordpress/scripts": "^32.5.1"
+        "@wordpress/scripts": "^32.6.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@parcel/watcher": "^2",
     "@types/node": "^22",
-    "@wordpress/scripts": "^32.5.1",
+    "@wordpress/scripts": "^32.6.0",
     "autoprefixer": "^10.4",
     "css-minimizer-webpack-plugin": "^8.0",
     "eslint-plugin-prettier": "^5.5",

--- a/plugins/lwtv-plugin/php/blocks/package.json
+++ b/plugins/lwtv-plugin/php/blocks/package.json
@@ -19,20 +19,20 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
-		"@wordpress/api-fetch": "^7.49.0",
-		"@wordpress/babel-plugin-import-jsx-pragma": "^5.49.0",
-		"@wordpress/block-editor": "^15.22.1",
-		"@wordpress/blocks": "^15.22.0",
-		"@wordpress/components": "^36.0.1",
-		"@wordpress/data": "^10.49.0",
-		"@wordpress/editor": "^14.49.1",
-		"@wordpress/element": "^8.1.0",
-		"@wordpress/i18n": "^6.22.0",
-		"@wordpress/icons": "^15.0.0",
-		"@wordpress/plugins": "^7.49.1",
-		"@wordpress/server-side-render": "^6.25.1"
+		"@wordpress/api-fetch": "^7.50.0",
+		"@wordpress/babel-plugin-import-jsx-pragma": "^5.50.0",
+		"@wordpress/block-editor": "^15.23.0",
+		"@wordpress/blocks": "^15.23.0",
+		"@wordpress/components": "^36.1.0",
+		"@wordpress/data": "^10.50.0",
+		"@wordpress/editor": "^14.50.0",
+		"@wordpress/element": "^8.2.0",
+		"@wordpress/i18n": "^6.23.0",
+		"@wordpress/icons": "^15.1.0",
+		"@wordpress/plugins": "^7.50.0",
+		"@wordpress/server-side-render": "^6.26.0"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^32.5.1"
+		"@wordpress/scripts": "^32.6.0"
 	}
 }

--- a/plugins/lwtv-plugin/php/cpts/class-post-meta.php
+++ b/plugins/lwtv-plugin/php/cpts/class-post-meta.php
@@ -79,9 +79,10 @@ class Post_Meta {
 			'show_in_rest' => false,
 		),
 		'lezactors_saved_wikidata'      => array(
-			'post_type'  => CPT_Actors::SLUG,
-			'type'       => 'object',
-			'items_type' => 'string',
+			'post_type'    => CPT_Actors::SLUG,
+			'type'         => 'object',
+			'items_type'   => 'string',
+			'show_in_rest' => false,
 		),
 		'lezactors_queer_override'      => array(
 			'post_type' => CPT_Actors::SLUG,

--- a/plugins/lwtv-plugin/php/cpts/shows/class-ways-to-watch.php
+++ b/plugins/lwtv-plugin/php/cpts/shows/class-ways-to-watch.php
@@ -62,10 +62,26 @@ class Ways_To_Watch {
 	 */
 	public function migrate_ways_to_watch( int $show_id ): void {
 		$old_watch_urls = get_post_meta( $show_id, 'lezshows_affiliate', true );
-		$new_watch_urls = get_post_meta( $show_id, 'lezshows_waystowatch', true );
+		$new_watch_urls = get_field( 'lezshows_waystowatch', $show_id );
 
 		if ( empty( $new_watch_urls ) && ! empty( $old_watch_urls ) ) {
-			update_post_meta( $show_id, 'lezshows_waystowatch', $old_watch_urls );
+			// Write the ACF repeater's indexed subfield rows directly rather than
+			// dumping the legacy flat value into the repeater's raw count key.
+			$count = 0;
+			foreach ( (array) $old_watch_urls as $url ) {
+				$url = esc_url_raw( trim( $url ) );
+
+				if ( empty( $url ) ) {
+					continue;
+				}
+
+				$key = "lezshows_waystowatch_{$count}_url";
+				update_post_meta( $show_id, $key, $url );
+				update_post_meta( $show_id, "_$key", 'field_lwtv_lezshows_waystowatch_url' );
+				++$count;
+			}
+			update_post_meta( $show_id, 'lezshows_waystowatch', $count );
+			update_post_meta( $show_id, '_lezshows_waystowatch', 'field_lwtv_lezshows_waystowatch' );
 			delete_post_meta( $show_id, 'lezshows_affiliate' );
 		}
 	}

--- a/plugins/lwtv-plugin/php/features/class-shortcodes.php
+++ b/plugins/lwtv-plugin/php/features/class-shortcodes.php
@@ -121,8 +121,11 @@ class Shortcodes {
 		}
 
 		// Death count: query row meta keys for the exact year-month.
+		// ACF's date_picker stores raw postmeta as Ymd; legacy pre-migration
+		// rows that haven't been re-saved may still be in Y-m-d format.
 		global $wpdb;
-		$like          = $wpdb->esc_like( $datetime->format( 'Y-m' ) . '-' ) . '%';
+		$like_ymd      = $wpdb->esc_like( $datetime->format( 'Ym' ) ) . '%';
+		$like_legacy   = $wpdb->esc_like( $datetime->format( 'Y-m' ) . '-' ) . '%';
 		$meta_key_like = $wpdb->esc_like( 'lezchars_death_year_' ) . '%' . $wpdb->esc_like( '_date' );
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$dead_ids = $wpdb->get_col(
@@ -132,10 +135,11 @@ class Shortcodes {
 				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
 				WHERE pm.meta_key LIKE %s
-				AND pm.meta_value LIKE %s
+				AND ( pm.meta_value LIKE %s OR pm.meta_value LIKE %s )
 				AND tt.taxonomy = 'lez_cliches' AND t.slug = 'dead'",
 				$meta_key_like,
-				$like
+				$like_ymd,
+				$like_legacy
 			)
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/plugins/lwtv-plugin/php/rest-api/class-byq.php
+++ b/plugins/lwtv-plugin/php/rest-api/class-byq.php
@@ -455,11 +455,14 @@ class BYQ {
 		$day   = intval( $date_parts[1] );
 
 		// Build date patterns to match against stored dates
-		// We need to match any year with this month-day combination
+		// We need to match any year with this month-day combination.
+		// ACF's date_picker stores raw postmeta as Ymd; legacy pre-migration
+		// rows that haven't been re-saved may still be in Y-m-d format, so
+		// the separator between each part is optional.
 		$date_patterns = array();
 		$current_year  = gmdate( 'Y' );
 		for ( $year = 1950; $year <= $current_year; $year++ ) {
-			$date_patterns[] = sprintf( '%04d-%02d-%02d', $year, $month, $day );
+			$date_patterns[] = sprintf( '^%04d-?%02d-?%02d$', $year, $month, $day );
 		}
 
 		// Use REGEXP to match any of our date patterns

--- a/plugins/lwtv-plugin/php/rest-api/class-what-happened-json.php
+++ b/plugins/lwtv-plugin/php/rest-api/class-what-happened-json.php
@@ -152,7 +152,10 @@ class What_Happened_JSON {
 				break;
 			case 'day':
 				global $wpdb;
-				$date          = $datetime->format( 'Y-m-d' );
+				// ACF's date_picker stores raw postmeta as Ymd; legacy pre-migration
+				// rows that haven't been re-saved may still be in Y-m-d format.
+				$date_ymd      = $datetime->format( 'Ymd' );
+				$date_legacy   = $datetime->format( 'Y-m-d' );
 				$meta_key_like = $wpdb->esc_like( 'lezchars_death_year_' ) . '%' . $wpdb->esc_like( '_date' );
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 				$dead_ids = $wpdb->get_col(
@@ -162,10 +165,11 @@ class What_Happened_JSON {
 						INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 						INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
 						WHERE pm.meta_key LIKE %s
-						AND pm.meta_value = %s
+						AND pm.meta_value IN ( %s, %s )
 						AND tt.taxonomy = 'lez_cliches' AND t.slug = 'dead'",
 						$meta_key_like,
-						$date
+						$date_ymd,
+						$date_legacy
 					)
 				);
 				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/plugins/lwtv-plugin/php/statistics/build/class-dead.php
+++ b/plugins/lwtv-plugin/php/statistics/build/class-dead.php
@@ -339,7 +339,9 @@ class Dead {
 		$year_counts = array();
 
 		foreach ( $results as $row ) {
-			if ( preg_match( '/^(\d{4})-\d{2}-\d{2}$/', $row['meta_value'], $matches ) ) {
+			// ACF's date_picker stores raw postmeta as Ymd; legacy pre-migration
+			// rows that haven't been re-saved may still be in Y-m-d format.
+			if ( preg_match( '/^(\d{4})-?\d{2}-?\d{2}$/', $row['meta_value'], $matches ) ) {
 				$year = $matches[1];
 				if ( ! isset( $year_counts[ $year ] ) ) {
 					$year_counts[ $year ] = 0;

--- a/template-parts/partials/actors/life.php
+++ b/template-parts/partials/actors/life.php
@@ -22,22 +22,24 @@ $died = get_post_meta( $actor, 'lezactors_death', true );
 
 // If they have a birthday, let's parse it.
 if ( ! empty( $born ) && ! lwtv_plugin()->hide_actor_data( $actor, 'dob' ) ) {
-	$barr = explode( '-', $born );
-	if ( isset( $barr[1] ) && isset( $barr[2] ) && checkdate( (int) $barr[1], (int) $barr[2], (int) $barr[0] ) ) {
+	try {
 		$get_birth = new DateTime( $born );
 
 		$life_array['dates']['born'] = date_format( $get_birth, 'F j, Y' );
+	} catch ( Exception $e ) {
+		lwtv_plugin()->error_log( 'actors', 'Invalid lezactors_birth date for actor ' . $actor . ': ' . $e->getMessage() );
 	}
 }
 
 // If they have a death date, let's parse it.
 if ( ! empty( $died ) ) {
-	$darr = explode( '-', $died );
-	if ( isset( $darr[1] ) && isset( $darr[2] ) && checkdate( (int) $darr[1], (int) $darr[2], (int) $darr[0] ) ) {
+	try {
 		$get_death = new DateTime( $died );
 
 		// Add died to array.
 		$life_array['dates']['died'] = date_format( $get_death, 'F j, Y' );
+	} catch ( Exception $e ) {
+		lwtv_plugin()->error_log( 'actors', 'Invalid lezactors_death date for actor ' . $actor . ': ' . $e->getMessage() );
 	}
 }
 

--- a/template-parts/partials/shows/card-altnames.php
+++ b/template-parts/partials/shows/card-altnames.php
@@ -12,7 +12,7 @@ if ( ! $show_id ) {
 	return;
 }
 
-$alt_names = ( get_post_meta( $show_id, 'lezshows_show_names', true ) ) ? get_post_meta( $show_id, 'lezshows_show_names', true ) : false;
+$alt_names = get_field( 'lezshows_show_names', $show_id );
 
 if ( false !== $alt_names && ! empty( $alt_names ) ) {
 	?>


### PR DESCRIPTION
This PR hardens date and ACF field handling across the actor/show data layer to account for format drift introduced by the CMB2→ACF migration, and locks down a leaked ACF meta field. It also bumps `@wordpress/*` packages to their latest minor releases.

### Fixes

- **Date format compatibility:** Support both `Ymd` (ACF's raw `date_picker` storage format) and legacy `Y-m-d` values when querying death dates in [`[class-shortcodes.php](https://claude.ai/epitaxy/plugins/lwtv-plugin/php/features/class-shortcodes.php)`](plugins/lwtv-plugin/php/features/class-shortcodes.php), [`[class-byq.php](https://claude.ai/epitaxy/plugins/lwtv-plugin/php/rest-api/class-byq.php)`](plugins/lwtv-plugin/php/rest-api/class-byq.php), [`[class-what-happened-json.php](https://claude.ai/epitaxy/plugins/lwtv-plugin/php/rest-api/class-what-happened-json.php)`](plugins/lwtv-plugin/php/rest-api/class-what-happened-json.php), and [`[class-dead.php](https://claude.ai/epitaxy/plugins/lwtv-plugin/php/statistics/build/class-dead.php)`](plugins/lwtv-plugin/php/statistics/build/class-dead.php).
- **Actor date parsing:** Wrap birth/death date parsing in [`[life.php](https://claude.ai/epitaxy/template-parts/partials/actors/life.php)`](template-parts/partials/actors/life.php) with `try`/`catch` instead of manual `checkdate()` validation, and log invalid dates via `error_log()` rather than silently dropping them.
- **Ways to Watch migration:** Rewrite [`[migrate_ways_to_watch()](https://claude.ai/epitaxy/plugins/lwtv-plugin/php/cpts/shows/class-ways-to-watch.php)`](plugins/lwtv-plugin/php/cpts/shows/class-ways-to-watch.php) to read the current value via `get_field()` and, when migrating legacy `lezshows_affiliate` URLs, write each URL into the ACF repeater's indexed subfield rows (`lezshows_waystowatch_{n}_url`) instead of dumping the flat array into the repeater's count key.
- **Show alt names:** Use `get_field( 'lezshows_show_names', $show_id )` in [`[card-altnames.php](https://claude.ai/epitaxy/template-parts/partials/shows/card-altnames.php)`](template-parts/partials/shows/card-altnames.php) instead of raw `get_post_meta()`.
- **REST API exposure:** Explicitly set `show_in_rest => false` for `lezactors_saved_wikidata` in [`[class-post-meta.php](https://claude.ai/epitaxy/plugins/lwtv-plugin/php/cpts/class-post-meta.php)`](plugins/lwtv-plugin/php/cpts/class-post-meta.php) to prevent it from leaking through the REST API.

### Misc

- Bump `@wordpress/scripts` and block-editor `@wordpress/*` dependencies to their latest minors in `package.json` and `plugins/lwtv-plugin/php/blocks/package.json`.
